### PR TITLE
feat(ai_session): add AI session management for tmux and zellij

### DIFF
--- a/internal/app/command_runner_test.go
+++ b/internal/app/command_runner_test.go
@@ -260,11 +260,11 @@ func TestAttachZellijSessionCmdUsesCommandRunner(t *testing.T) {
 		t.Fatal("expected command to be returned")
 	}
 
-	if capture.name != "zellij" {
+	if capture.name != multiplexerZellij {
 		t.Fatalf("expected zellij command, got %q", capture.name)
 	}
 	if len(capture.args) != 2 || capture.args[0] != onExistsAttach || capture.args[1] != testSessionName {
-		t.Fatalf("unexpected zellij args: %v", capture.args)
+		t.Fatalf("unexpected %s args: %v", multiplexerZellij, capture.args)
 	}
 }
 

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -479,6 +479,17 @@ func (m *Model) handleBuiltInKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "g":
 		return m, m.openLazyGit()
 
+	case "a":
+		// AI session: launch or switch to session
+		// Always use launchAISession which handles both create and switch (via on_exists: switch)
+		if m.config.AISession != nil {
+			if m.selectedIndex >= 0 && m.selectedIndex < len(m.filteredWts) {
+				wt := m.filteredWts[m.selectedIndex]
+				return m, m.launchAISession(wt)
+			}
+		}
+		return m, nil
+
 	case "o":
 		return m, m.openPR()
 

--- a/internal/app/screens.go
+++ b/internal/app/screens.go
@@ -696,6 +696,7 @@ func NewHelpScreen(maxWidth, maxHeight int, customCommands map[string]*config.Cu
 - d: Full-screen diff viewer
 - o: Open PR/MR in browser
 - g: Open LazyGit (or go to top in diff pane)
+- a: AI session (launch or switch to existing)
 - =: Toggle zoom for focused pane
 - : / Ctrl+P: Command Palette
 - ?: Show this help
@@ -725,6 +726,12 @@ Search Mode:
 - ✎: Uncommitted changes (dirty)
 - ↑N: Ahead of remote by N commits
 - ↓N: Behind remote by N commits
+
+**🤖 AI Session Indicators** (when enabled)
+- ●: AI session ready/idle
+- ◐◓◑◒: AI session working (animated)
+- ✗: AI session error
+- -: No AI session
 
 **❓ Help Navigation**
 - /: Search help (Enter to apply, Esc to clear)

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -1,6 +1,8 @@
 // Package models defines the data objects shared across lazyworktree packages.
 package models
 
+import "time"
+
 // CommitFile represents a file changed in a commit.
 type CommitFile struct {
 	Filename   string
@@ -40,6 +42,14 @@ type CICheck struct {
 	Conclusion string // Conclusion: "success", "failure", "skipped", "cancelled", etc.
 }
 
+// AISessionStatus represents the current state of an AI session for a worktree.
+// Status is written by the AI tool via hooks to a file in the worktree root.
+type AISessionStatus struct {
+	Status    string    `json:"status"`     // Status: "idle", "working", "error"
+	UpdatedAt time.Time `json:"updated_at"` // When the status was last updated
+	Message   string    `json:"message"`    // Optional status message
+}
+
 // WorktreeInfo summarizes the information for a git worktree.
 type WorktreeInfo struct {
 	Path           string
@@ -54,6 +64,7 @@ type WorktreeInfo struct {
 	LastActiveTS   int64
 	LastSwitchedTS int64 // Unix timestamp of last UI access/switch
 	PR             *PRInfo
+	AISession      *AISessionStatus // AI session status (nil if no session)
 	Untracked      int
 	Modified       int
 	Staged         int
@@ -69,4 +80,6 @@ const (
 	CommandHistoryFilename = ".command-history.json"
 	// AccessHistoryFilename stores worktree access timestamps for sorting.
 	AccessHistoryFilename = ".worktree-access.json"
+	// AISessionStatusFilename stores the AI session status in the worktree root.
+	AISessionStatusFilename = ".ai-status.json"
 )

--- a/lazyworktree.1
+++ b/lazyworktree.1
@@ -266,6 +266,11 @@ Open command palette showing all available commands.
 .B g
 Open LazyGit for the currently selected worktree.
 .
+.SS AI Session Management
+.TP
+.B a
+Launch AI session for the selected worktree (if none exists) or switch to an existing AI session. Requires \fBai_session.enabled: true\fR in configuration.
+.
 .SH MOUSE SUPPORT
 lazyworktree provides comprehensive mouse support for improved navigation and interaction:
 .
@@ -551,6 +556,79 @@ custom_create_menus:
     interactive: true
     post_command: "git commit --allow-empty -m 'Initial commit for ${WORKTREE_BRANCH}'"
     post_interactive: false
+.fi
+.RE
+.
+.SS AI Session Management
+.TP
+.B ai_session
+Configuration for managing AI coding tool sessions (Claude Code, Aider, Codex, etc.) in tmux or zellij.
+.PP
+AI session fields:
+.RS
+.IP \(bu 2
+\fBenabled\fR: Enable AI session management (default: false)
+.IP \(bu 2
+\fBmultiplexer\fR: Terminal multiplexer to use: "tmux" or "zellij" (default: tmux)
+.IP \(bu 2
+\fBsession_prefix\fR: Session name prefix, supports env vars like ${REPO_NAME} (default: ${REPO_NAME}_ai_)
+.IP \(bu 2
+\fBcommand\fR: AI tool command to execute (default: claude)
+.IP \(bu 2
+\fBpoll_interval\fR: Status file poll interval in seconds (default: 5)
+.IP \(bu 2
+\fBwindow_name\fR: Window/tab name for the AI session (default: ai)
+.RE
+.PP
+AI tools can report their status by writing to \fB.ai-status.json\fR in the worktree root. The status file format is:
+.RS
+.nf
+{
+  "status": "idle",
+  "updated_at": "2024-01-11T12:34:56Z",
+  "message": "Optional status message"
+}
+.fi
+.RE
+.PP
+Status values: \fBidle\fR (ready for input), \fBworking\fR (processing), \fBerror\fR.
+.PP
+Status indicators in the worktree table:
+.IP \(bu 2
+● Active/idle (session exists, ready for input)
+.IP \(bu 2
+◐◓◑◒ Working (animated spinner when AI tool is processing)
+.IP \(bu 2
+✗ Error
+.IP \(bu 2
+- No session
+.PP
+Example configuration:
+.RS
+.nf
+ai_session:
+  enabled: true
+  multiplexer: tmux
+  session_prefix: "${REPO_NAME}_ai_"
+  command: claude
+  poll_interval: 5
+  window_name: ai
+.fi
+.RE
+.PP
+To enable status reporting with Claude Code, configure hooks in \fB~/.claude/settings.json\fR:
+.RS
+.nf
+{
+  "hooks": {
+    "PreToolUse": [{
+      "command": "echo '{\\"status\\":\\"working\\"}' > .ai-status.json"
+    }],
+    "Stop": [{
+      "command": "echo '{\\"status\\":\\"idle\\"}' > .ai-status.json"
+    }]
+  }
+}
 .fi
 .RE
 .


### PR DESCRIPTION
- add ai_session config section to enable/manage AI tool sessions per worktree
- show AI session status (idle, working spinner, error) in the worktree table column
- add keybinding a to launch or switch to AI session for selected worktree

_____


