### PR TITLE
add worktree note script

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,8 @@ issue_branch_name_template: "issue-{number}-{title}" # Placeholders: {number}, {
 pr_branch_name_template: "pr-{number}-{title}" # Placeholders: {number}, {title}, {generated}, {pr_author}
 # Automatic branch name generation (see "Automatically Generated Branch Names")
 branch_name_script: "" # Script to generate names from diff/issue/PR content
+# Automatic worktree note generation when creating from PR/MR or issue
+worktree_note_script: "" # Script to generate notes from PR/issue title+body
 init_commands:
   - link_topsymlinks
 terminate_commands:
@@ -405,6 +407,7 @@ CI environment variables: `LW_CI_JOB_NAME`, `LW_CI_JOB_NAME_CLEAN`, `LW_CI_RUN_I
 * `branch_name_script`: script for automatic branch suggestions. See [Automatically generated branch names](#automatically-generated-branch-names).
 * `issue_branch_name_template`: template with placeholders `{number}`, `{title}`, `{generated}`.
 * `pr_branch_name_template`: template with placeholders `{number}`, `{title}`, `{generated}`, `{pr_author}`.
+* `worktree_note_script`: script for automatic worktree notes when creating from PR/MR or issue.
 
 **Custom create menu**
 
@@ -727,6 +730,24 @@ branch_name_script: |
 branch_name_script: |
   aichat -m gemini:gemini-2.5-flash-lite "Generate a title for item #$LAZYWORKTREE_NUMBER. Output only the title."
 ```
+
+## Automatically Generated Worktree Notes
+
+Configure `worktree_note_script` to generate initial worktree notes when creating from a PR/MR or issue. The script receives the selected item's title and body on stdin and can produce multiline output. If the script fails or outputs nothing, creation continues and no note is saved.
+
+### Configuration
+
+```yaml
+worktree_note_script: "aichat -m gemini:gemini-2.5-flash-lite 'Summarise this ticket into practical implementation notes.'"
+```
+
+### Script Requirements
+
+Receives content on stdin, outputs note text on stdout. Timeout: 30s.
+
+### Environment Variables
+
+`LAZYWORKTREE_TYPE` (pr/issue), `LAZYWORKTREE_NUMBER`, `LAZYWORKTREE_TITLE`, `LAZYWORKTREE_URL`.
 
 ## CLI Usage
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -183,6 +183,23 @@ pr_branch_name_template: "pr-{number}-{title}"
 #
 # branch_name_script: ""
 
+# Script to generate an initial worktree note when creating from a PR/MR or issue
+#
+# The script receives content on stdin (title + body from the selected PR/MR or issue)
+#
+# Environment variables available to the script:
+#   LAZYWORKTREE_TYPE: The source type (pr/issue)
+#   LAZYWORKTREE_NUMBER: The PR/MR or issue number
+#   LAZYWORKTREE_TITLE: The PR/MR or issue title
+#   LAZYWORKTREE_URL: The PR/MR or issue URL
+#
+# If the script fails or outputs nothing, creation continues without writing a note.
+#
+# Example:
+#   worktree_note_script: "aichat -m gemini:gemini-2.5-flash-lite 'Summarise this ticket as concise implementation notes.'"
+#
+# worktree_note_script: ""
+
 # ============================================================================
 # GIT OPERATIONS
 # ============================================================================

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -154,6 +154,7 @@ type (
 		prNumber   int
 		branch     string
 		targetPath string
+		note       string
 		err        error
 	}
 	openIssuesLoadedMsg struct {
@@ -164,6 +165,7 @@ type (
 		issueNumber int
 		branch      string
 		targetPath  string
+		note        string
 		err         error
 	}
 	renameWorktreeResultMsg struct {
@@ -639,6 +641,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.showInfo(fmt.Sprintf("Failed to create worktree from PR/MR #%d: %v", msg.prNumber, msg.err), nil)
 			return m, nil
 		}
+		if strings.TrimSpace(msg.note) != "" {
+			m.setWorktreeNote(msg.targetPath, msg.note)
+		}
 		env := m.buildCommandEnv(msg.branch, msg.targetPath)
 		initCmds := m.collectInitCommands()
 		after := func() tea.Msg {
@@ -654,6 +659,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.pendingSelectWorktreePath = ""
 			m.showInfo(fmt.Sprintf("Failed to create worktree from issue #%d: %v", msg.issueNumber, msg.err), nil)
 			return m, nil
+		}
+		if strings.TrimSpace(msg.note) != "" {
+			m.setWorktreeNote(msg.targetPath, msg.note)
 		}
 		env := m.buildCommandEnv(msg.branch, msg.targetPath)
 		initCmds := m.collectInitCommands()

--- a/internal/app/helpers.go
+++ b/internal/app/helpers.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/chmouel/lazyworktree/internal/app/services"
 	"github.com/chmouel/lazyworktree/internal/models"
 	"github.com/chmouel/lazyworktree/internal/utils"
 )
@@ -61,6 +62,21 @@ func runBranchNameScript(ctx context.Context, script, content, scriptType, numbe
 	}
 
 	return strings.TrimSpace(output), nil
+}
+
+func (m *Model) generateWorktreeNote(contentType string, number int, title, body, url string) (string, error) {
+	if strings.TrimSpace(m.config.WorktreeNoteScript) == "" {
+		return "", nil
+	}
+
+	content := fmt.Sprintf("%s\n\n%s", title, body)
+	return services.RunWorktreeNoteScript(m.ctx, m.config.WorktreeNoteScript, services.WorktreeNoteScriptInput{
+		Content: content,
+		Type:    contentType,
+		Number:  number,
+		Title:   title,
+		URL:     url,
+	})
 }
 
 func fuzzyScoreLower(query, target string) (int, bool) {

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -461,7 +461,16 @@ func (m *Model) handleOpenPRsLoaded(msg openPRsLoadedMsg) tea.Cmd {
 					err:        fmt.Errorf("create worktree from PR/MR branch %q", remoteBranch),
 				}
 			}
-			return createFromPRResultMsg{prNumber: pr.Number, branch: localBranch, targetPath: targetPath}
+			noteText, err := m.generateWorktreeNote("pr", pr.Number, pr.Title, pr.Body, pr.URL)
+			if err != nil {
+				m.debugf("worktree note script error for PR/MR #%d: %v", pr.Number, err)
+			}
+			return createFromPRResultMsg{
+				prNumber:   pr.Number,
+				branch:     localBranch,
+				targetPath: targetPath,
+				note:       noteText,
+			}
 		}
 	}
 	prScr.OnCancel = func() tea.Cmd {
@@ -589,7 +598,16 @@ func (m *Model) handleOpenIssuesLoaded(msg openIssuesLoadedMsg) tea.Cmd {
 								err:         fmt.Errorf("create worktree from issue #%d", issue.Number),
 							}
 						}
-						return createFromIssueResultMsg{issueNumber: issue.Number, branch: newBranch, targetPath: targetPath}
+						noteText, err := m.generateWorktreeNote("issue", issue.Number, issue.Title, issue.Body, issue.URL)
+						if err != nil {
+							m.debugf("worktree note script error for issue #%d: %v", issue.Number, err)
+						}
+						return createFromIssueResultMsg{
+							issueNumber: issue.Number,
+							branch:      newBranch,
+							targetPath:  targetPath,
+							note:        noteText,
+						}
 					}
 				}
 

--- a/internal/app/pr_worktree_test.go
+++ b/internal/app/pr_worktree_test.go
@@ -104,6 +104,64 @@ func TestCreateFromPRResultMsgError(t *testing.T) {
 	}
 }
 
+func TestCreateFromPRResultMsgSuccessSavesGeneratedNote(t *testing.T) {
+	cfg := &config.AppConfig{
+		WorktreeDir: t.TempDir(),
+	}
+	m := NewModel(cfg, "")
+	m.repoKey = "test/repo"
+	m.setWindowSize(120, 40)
+	m.loading = true
+	m.setLoadingScreen("Creating worktree...")
+
+	targetPath := filepath.Join(cfg.WorktreeDir, "pr-123")
+	msg := createFromPRResultMsg{
+		prNumber:   123,
+		branch:     "feature-branch",
+		targetPath: targetPath,
+		note:       "Generated note",
+	}
+
+	_, _ = m.Update(msg)
+
+	note, ok := m.getWorktreeNote(targetPath)
+	if !ok {
+		t.Fatal("expected generated note to be stored")
+	}
+	if note.Note != "Generated note" {
+		t.Fatalf("unexpected note text: %q", note.Note)
+	}
+}
+
+func TestCreateFromIssueResultMsgSuccessSavesGeneratedNote(t *testing.T) {
+	cfg := &config.AppConfig{
+		WorktreeDir: t.TempDir(),
+	}
+	m := NewModel(cfg, "")
+	m.repoKey = "test/repo"
+	m.setWindowSize(120, 40)
+	m.loading = true
+	m.setLoadingScreen("Creating worktree...")
+
+	targetPath := filepath.Join(cfg.WorktreeDir, "issue-123")
+	msg := createFromIssueResultMsg{
+		issueNumber: 123,
+		branch:      "issue-123",
+		targetPath:  targetPath,
+		note:        "Issue generated note",
+	}
+
+	_, _ = m.Update(msg)
+
+	note, ok := m.getWorktreeNote(targetPath)
+	if !ok {
+		t.Fatal("expected generated note to be stored")
+	}
+	if note.Note != "Issue generated note" {
+		t.Fatalf("unexpected note text: %q", note.Note)
+	}
+}
+
 // TestHandleWorktreesLoadedSelectsPendingPath tests that worktrees are selected after creation.
 func TestHandleWorktreesLoadedSelectsPendingPath(t *testing.T) {
 	cfg := &config.AppConfig{

--- a/internal/app/screen/help.go
+++ b/internal/app/screen/help.go
@@ -88,6 +88,7 @@ When CI checks are displayed in the info panel:
 - c: Create new worktree (branch, commit, PR/MR, issue, or custom)
 - Create from current: supply an explicit name or leave empty for auto-generation
 - Create from PR/MR: worktree name is generated from the PR template/script; branch name uses the PR branch when you are the author, otherwise uses the generated name
+- Create from PR/MR or issue can auto-add a note when worktree_note_script is configured
 - Existing local branch: choose to checkout the branch or create a new one based on it
 - Tab / Shift+Tab: Move focus to the "Include current file changes" checkbox
 - Space: Toggle "Include current file changes"

--- a/internal/app/services/note_script.go
+++ b/internal/app/services/note_script.go
@@ -1,0 +1,53 @@
+package services
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const worktreeNoteScriptTimeout = 30 * time.Second
+
+// WorktreeNoteScriptInput contains the context passed to worktree_note_script.
+type WorktreeNoteScriptInput struct {
+	Content string
+	Type    string
+	Number  int
+	Title   string
+	URL     string
+}
+
+// RunWorktreeNoteScript executes worktree_note_script and returns the generated note text.
+func RunWorktreeNoteScript(ctx context.Context, script string, input WorktreeNoteScriptInput) (string, error) {
+	script = strings.TrimSpace(script)
+	if script == "" {
+		return "", nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, worktreeNoteScriptTimeout)
+	defer cancel()
+
+	// #nosec G204 -- script is user-configured and trusted
+	cmd := exec.CommandContext(ctx, "bash", "-c", script)
+	cmd.Stdin = strings.NewReader(input.Content)
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("LAZYWORKTREE_TYPE=%s", input.Type),
+		fmt.Sprintf("LAZYWORKTREE_NUMBER=%d", input.Number),
+		fmt.Sprintf("LAZYWORKTREE_TITLE=%s", input.Title),
+		fmt.Sprintf("LAZYWORKTREE_URL=%s", input.URL),
+	)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("worktree note script failed: %w (stderr: %s)", err, strings.TrimSpace(stderr.String()))
+	}
+
+	return strings.TrimSpace(stdout.String()), nil
+}

--- a/internal/app/services/note_script_test.go
+++ b/internal/app/services/note_script_test.go
@@ -1,0 +1,67 @@
+package services
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestRunWorktreeNoteScriptSuccess(t *testing.T) {
+	t.Parallel()
+
+	note, err := RunWorktreeNoteScript(context.Background(), "cat", WorktreeNoteScriptInput{
+		Content: "line one\nline two\n",
+		Type:    "issue",
+		Number:  42,
+		Title:   "Issue title",
+		URL:     "https://example.com/issues/42",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if note != "line one\nline two" {
+		t.Fatalf("unexpected note: %q", note)
+	}
+}
+
+func TestRunWorktreeNoteScriptEnv(t *testing.T) {
+	t.Parallel()
+
+	script := `printf "%s|%s|%s|%s" "$LAZYWORKTREE_TYPE" "$LAZYWORKTREE_NUMBER" "$LAZYWORKTREE_TITLE" "$LAZYWORKTREE_URL"`
+	note, err := RunWorktreeNoteScript(context.Background(), script, WorktreeNoteScriptInput{
+		Type:   "pr",
+		Number: 123,
+		Title:  "Fix bug",
+		URL:    "https://example.com/pr/123",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if note != "pr|123|Fix bug|https://example.com/pr/123" {
+		t.Fatalf("unexpected env output: %q", note)
+	}
+}
+
+func TestRunWorktreeNoteScriptFailure(t *testing.T) {
+	t.Parallel()
+
+	_, err := RunWorktreeNoteScript(context.Background(), "echo boom >&2; exit 1", WorktreeNoteScriptInput{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "worktree note script failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunWorktreeNoteScriptEmpty(t *testing.T) {
+	t.Parallel()
+
+	note, err := RunWorktreeNoteScript(context.Background(), "printf '   '", WorktreeNoteScriptInput{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if note != "" {
+		t.Fatalf("expected empty note, got %q", note)
+	}
+}

--- a/internal/app/services/worktree_notes_mutation.go
+++ b/internal/app/services/worktree_notes_mutation.go
@@ -1,0 +1,32 @@
+package services
+
+import (
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/chmouel/lazyworktree/internal/models"
+)
+
+// SaveWorktreeNote stores a single note for a worktree path.
+func SaveWorktreeNote(repoKey, worktreeDir, worktreePath, noteText string) error {
+	trimmedPath := strings.TrimSpace(worktreePath)
+	trimmedNote := strings.TrimSpace(noteText)
+	if trimmedPath == "" || trimmedNote == "" {
+		return nil
+	}
+
+	notes, err := LoadWorktreeNotes(repoKey, worktreeDir)
+	if err != nil {
+		return err
+	}
+	if notes == nil {
+		notes = map[string]models.WorktreeNote{}
+	}
+
+	notes[filepath.Clean(trimmedPath)] = models.WorktreeNote{
+		Note:      trimmedNote,
+		UpdatedAt: time.Now().Unix(),
+	}
+	return SaveWorktreeNotes(repoKey, worktreeDir, notes)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -96,6 +96,7 @@ type AppConfig struct {
 	RefreshIntervalSeconds  int
 	CustomCommands          map[string]*CustomCommand
 	BranchNameScript        string // Script to generate branch name suggestions from diff
+	WorktreeNoteScript      string // Script to generate worktree notes from PR/issue content
 	Theme                   string // Theme name: see AvailableThemes in internal/theme
 	MergeMethod             string // Merge method for absorb: "rebase" or "merge" (default: "rebase")
 	FuzzyFinderInput        bool   // Enable fuzzy finder for input suggestions (default: false)
@@ -310,6 +311,13 @@ func parseConfig(data map[string]any) (*AppConfig, error) {
 		branchNameScript = strings.TrimSpace(branchNameScript)
 		if branchNameScript != "" {
 			cfg.BranchNameScript = branchNameScript
+		}
+	}
+
+	if worktreeNoteScript, ok := data["worktree_note_script"].(string); ok {
+		worktreeNoteScript = strings.TrimSpace(worktreeNoteScript)
+		if worktreeNoteScript != "" {
+			cfg.WorktreeNoteScript = worktreeNoteScript
 		}
 	}
 
@@ -808,6 +816,9 @@ func (cfg *AppConfig) ApplyCLIOverrides(overrides []string) error {
 	}
 	if overrideCfg.BranchNameScript != "" {
 		cfg.BranchNameScript = overrideCfg.BranchNameScript
+	}
+	if overrideCfg.WorktreeNoteScript != "" {
+		cfg.WorktreeNoteScript = overrideCfg.WorktreeNoteScript
 	}
 	if overrideCfg.IssueBranchNameTemplate != "" {
 		cfg.IssueBranchNameTemplate = overrideCfg.IssueBranchNameTemplate

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -37,6 +37,7 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Empty(t, cfg.BranchNameScript)
 	assert.Equal(t, "issue-{number}-{title}", cfg.IssueBranchNameTemplate)
 	assert.Equal(t, "pr-{number}-{title}", cfg.PRBranchNameTemplate)
+	assert.Empty(t, cfg.WorktreeNoteScript)
 	assert.Equal(t, "default", cfg.Layout)
 }
 
@@ -902,6 +903,33 @@ func TestParseConfig(t *testing.T) {
 			},
 			validate: func(t *testing.T, cfg *AppConfig) {
 				assert.Equal(t, "review-{number}-{title}", cfg.PRBranchNameTemplate)
+			},
+		},
+		{
+			name: "worktree_note_script",
+			data: map[string]interface{}{
+				"worktree_note_script": "echo note",
+			},
+			validate: func(t *testing.T, cfg *AppConfig) {
+				assert.Equal(t, "echo note", cfg.WorktreeNoteScript)
+			},
+		},
+		{
+			name: "worktree_note_script empty string",
+			data: map[string]interface{}{
+				"worktree_note_script": "",
+			},
+			validate: func(t *testing.T, cfg *AppConfig) {
+				assert.Empty(t, cfg.WorktreeNoteScript)
+			},
+		},
+		{
+			name: "worktree_note_script with spaces is trimmed",
+			data: map[string]interface{}{
+				"worktree_note_script": "   echo note   ",
+			},
+			validate: func(t *testing.T, cfg *AppConfig) {
+				assert.Equal(t, "echo note", cfg.WorktreeNoteScript)
 			},
 		},
 		{
@@ -2112,6 +2140,7 @@ func TestApplyCLIOverrides(t *testing.T) {
 		"lw.disable_pr=true",
 		"lw.max_diff_chars=500000",
 		"lw.pr_branch_name_template=review-{number}-{generated}",
+		"lw.worktree_note_script=echo note",
 	}
 
 	err := cfg.ApplyCLIOverrides(overrides)
@@ -2122,6 +2151,7 @@ func TestApplyCLIOverrides(t *testing.T) {
 	assert.True(t, cfg.DisablePR)
 	assert.Equal(t, 500000, cfg.MaxDiffChars)
 	assert.Equal(t, "review-{number}-{generated}", cfg.PRBranchNameTemplate)
+	assert.Equal(t, "echo note", cfg.WorktreeNoteScript)
 }
 
 func TestApplyCLIOverridesMultiValue(t *testing.T) {

--- a/lazyworktree.1
+++ b/lazyworktree.1
@@ -99,7 +99,7 @@ Override config values from the command line (repeatable).
 .br
 Format: \fB--config=lw.key=value\fR
 .br
-Supported keys: \fBtheme\fR, \fBworktree_dir\fR, \fBsort_mode\fR, \fBauto_refresh\fR, \fBdisable_pr\fR, \fBsearch_auto_select\fR, \fBfuzzy_finder_input\fR, \fBicon_set\fR, \fBpalette_mru\fR, \fBpalette_mru_limit\fR, \fBgit_pager\fR, \fBgit_pager_args\fR, \fBgit_pager_interactive\fR, \fBgit_pager_command_mode\fR, \fBpager\fR, \fBeditor\fR, \fBmax_untracked_diffs\fR, \fBmax_diff_chars\fR, \fBrefresh_interval_seconds\fR, \fBtrust_mode\fR, \fBmerge_method\fR, \fBbranch_name_script\fR, \fBissue_branch_name_template\fR, \fBpr_branch_name_template\fR, \fBsession_prefix\fR, \fBinit_commands\fR, \fBterminate_commands\fR.
+Supported keys: \fBtheme\fR, \fBworktree_dir\fR, \fBsort_mode\fR, \fBauto_refresh\fR, \fBdisable_pr\fR, \fBsearch_auto_select\fR, \fBfuzzy_finder_input\fR, \fBicon_set\fR, \fBpalette_mru\fR, \fBpalette_mru_limit\fR, \fBgit_pager\fR, \fBgit_pager_args\fR, \fBgit_pager_interactive\fR, \fBgit_pager_command_mode\fR, \fBpager\fR, \fBeditor\fR, \fBmax_untracked_diffs\fR, \fBmax_diff_chars\fR, \fBrefresh_interval_seconds\fR, \fBtrust_mode\fR, \fBmerge_method\fR, \fBbranch_name_script\fR, \fBworktree_note_script\fR, \fBissue_branch_name_template\fR, \fBpr_branch_name_template\fR, \fBsession_prefix\fR, \fBinit_commands\fR, \fBterminate_commands\fR.
 .br
 Examples: \fB--config=lw.theme=nord\fR, \fB--config=lw.sort_mode=active\fR
 .br
@@ -957,6 +957,14 @@ Options: \fBrebase\fR (default - rebases onto main then fast-forwards, synchroni
 Script to generate branch name suggestions when creating worktrees from changes, issues, or PRs. For issues/PRs, the script should output a title (e.g., "feat-ai-session-manager") which will be sanitised and made available via the \fB{generated}\fR placeholder in your configured template. For diffs, the script should output a complete branch name. The script receives content on stdin (git diff for changes, issue/PR title and body for issues/PRs). First line of output is used.
 .br
 Available environment variables: LAZYWORKTREE_TYPE (pr/issue/diff), LAZYWORKTREE_NUMBER (PR/issue number), LAZYWORKTREE_TEMPLATE (configured template), LAZYWORKTREE_SUGGESTED_NAME (template-generated name using original PR/issue title).
+.br
+Script operates under a 30-second timeout.
+.
+.TP
+.B worktree_note_script
+Script to generate an initial worktree note when creating from a PR/MR or issue. The script receives title and body content on stdin and may return multiline output. If the script fails or returns empty output, worktree creation continues and no note is saved.
+.br
+Available environment variables: LAZYWORKTREE_TYPE (pr/issue), LAZYWORKTREE_NUMBER, LAZYWORKTREE_TITLE, LAZYWORKTREE_URL.
 .br
 Script operates under a 30-second timeout.
 .


### PR DESCRIPTION
This pull request adds support for automatically generating and saving worktree notes when creating a worktree from a PR/MR or issue. Users can configure a `worktree_note_script` that receives the PR/issue title and body, and outputs implementation notes that are then attached to the new worktree. The feature is documented, tested, and integrated into both the TUI and CLI workflows.

**Core feature: automatic worktree note generation**
- Added support for a `worktree_note_script` configuration option, allowing users to specify a script that generates worktree notes from PR/MR or issue content. The script receives the title and body via stdin and relevant metadata via environment variables. If the script fails or outputs nothing, worktree creation proceeds without a note. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R290-R291) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R408) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R726-R743) [[4]](diffhunk://#diff-c7f43f17867c7240c4a26f92d204f0999bba302964d8f9abbc10e9103ffb066aR174-R190)
- Implemented the logic to call the script and save the generated note in both TUI (`internal/app/app.go`, `internal/app/messages.go`) and CLI (`internal/cli/operations.go`) flows. [[1]](diffhunk://#diff-8c3b31d203de7539cf0fb4ccee21b40c0d804dd38ff99fc67ad18fc0d52361e7R644-R646) [[2]](diffhunk://#diff-8c3b31d203de7539cf0fb4ccee21b40c0d804dd38ff99fc67ad18fc0d52361e7R663-R665) [[3]](diffhunk://#diff-02db4f45aadcc75ce3271369a6edccbdd5dc8f389989dddaf18eb847af4db49aL433-R442) [[4]](diffhunk://#diff-02db4f45aadcc75ce3271369a6edccbdd5dc8f389989dddaf18eb847af4db49aL561-R579) [[5]](diffhunk://#diff-aa3947154fdf69afc6a4a3d82f03fea57e1b701bfa465820bbd63b70b83ba89eR275-R276) [[6]](diffhunk://#diff-aa3947154fdf69afc6a4a3d82f03fea57e1b701bfa465820bbd63b70b83ba89eR362-R363) [[7]](diffhunk://#diff-aa3947154fdf69afc6a4a3d82f03fea57e1b701bfa465820bbd63b70b83ba89eR597-R630)
- Added a new service (`internal/app/services/note_script.go`) to handle script execution, environment variable injection, and timeouts, along with comprehensive tests (`internal/app/services/note_script_test.go`). [[1]](diffhunk://#diff-1331c7a84c9b10a21cade6b5e8ad360aa639c68908a261b4ac103432e95ff56dR1-R53) [[2]](diffhunk://#diff-19ef86842e8807ee47491e89cb8212cc3137a5aa9a3eb2fa389ef96096d634e8R1-R67)

**Persistence and storage of notes**
- Introduced a new service (`internal/app/services/worktree_notes_mutation.go`) for saving generated notes, with tests for correct storage and handling of empty/whitespace notes. [[1]](diffhunk://#diff-2e8f686a766baf4295533c66f6e2424158fe018cfccfdc582e66ade2820b9891R1-R32) [[2]](diffhunk://#diff-0724fb69fb6ebda5739e57ec9c0c885775f7d65e666a85dbd4bd29e9bf5615e6R107-R149)

**Documentation and user guidance**
- Updated `README.md` and `config.example.yaml` with instructions, configuration examples, and environment variable documentation for the new feature. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R62-R63) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R290-R291) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R408) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R726-R743) [[5]](diffhunk://#diff-c7f43f17867c7240c4a26f92d204f0999bba302964d8f9abbc10e9103ffb066aR174-R190)
- Added help text in the TUI to inform users about the new automatic note feature.

**Testing**
- Added tests to verify that generated notes are saved correctly when worktrees are created from PRs or issues, and to ensure the note script and persistence logic behave as expected. [[1]](diffhunk://#diff-e451f4041b2fb794b79f08a17759e845a9134ae35c9b5be05d3cd9714a91247eR105-R162) [[2]](diffhunk://#diff-19ef86842e8807ee47491e89cb8212cc3137a5aa9a3eb2fa389ef96096d634e8R1-R67) [[3]](diffhunk://#diff-0724fb69fb6ebda5739e57ec9c0c885775f7d65e666a85dbd4bd29e9bf5615e6R107-R149)

**Relevant references:**  
[[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R290-R291) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R408) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R726-R743) [[4]](diffhunk://#diff-c7f43f17867c7240c4a26f92d204f0999bba302964d8f9abbc10e9103ffb066aR174-R190) [[5]](diffhunk://#diff-1331c7a84c9b10a21cade6b5e8ad360aa639c68908a261b4ac103432e95ff56dR1-R53) [[6]](diffhunk://#diff-19ef86842e8807ee47491e89cb8212cc3137a5aa9a3eb2fa389ef96096d634e8R1-R67) [[7]](diffhunk://#diff-2e8f686a766baf4295533c66f6e2424158fe018cfccfdc582e66ade2820b9891R1-R32) [[8]](diffhunk://#diff-0724fb69fb6ebda5739e57ec9c0c885775f7d65e666a85dbd4bd29e9bf5615e6R107-R149) [[9]](diffhunk://#diff-8c3b31d203de7539cf0fb4ccee21b40c0d804dd38ff99fc67ad18fc0d52361e7R644-R646) [[10]](diffhunk://#diff-8c3b31d203de7539cf0fb4ccee21b40c0d804dd38ff99fc67ad18fc0d52361e7R663-R665) [[11]](diffhunk://#diff-02db4f45aadcc75ce3271369a6edccbdd5dc8f389989dddaf18eb847af4db49aL433-R442) [[12]](diffhunk://#diff-02db4f45aadcc75ce3271369a6edccbdd5dc8f389989dddaf18eb847af4db49aL561-R579) [[13]](diffhunk://#diff-aa3947154fdf69afc6a4a3d82f03fea57e1b701bfa465820bbd63b70b83ba89eR275-R276) [[14]](diffhunk://#diff-aa3947154fdf69afc6a4a3d82f03fea57e1b701bfa465820bbd63b70b83ba89eR362-R363) [[15]](diffhunk://#diff-aa3947154fdf69afc6a4a3d82f03fea57e1b701bfa465820bbd63b70b83ba89eR597-R630) [[16]](diffhunk://#diff-e451f4041b2fb794b79f08a17759e845a9134ae35c9b5be05d3cd9714a91247eR105-R162) [[17]](diffhunk://#diff-c6f954950039265698d0133c3a9d669b1b374fed7a7cb6e1329469c57945348bR91)