### PR TITLE
fix: use org/repo layout for TUI worktrees

### DIFF
--- a/internal/app/worktree_operations.go
+++ b/internal/app/worktree_operations.go
@@ -174,14 +174,14 @@ func (m *Model) showCreateFromChangesInput(wt *models.WorktreeInfo, currentBranc
 		}
 
 		// Check if worktree path already exists
-		targetPath := filepath.Join(m.getWorktreeDir(), newBranch)
+		targetPath := filepath.Join(m.getRepoWorktreeDir(), newBranch)
 		if _, err := os.Stat(targetPath); err == nil {
 			inputScr.ErrorMsg = fmt.Sprintf("Path already exists: %s", targetPath)
 			return nil
 		}
 
 		inputScr.ErrorMsg = ""
-		if err := os.MkdirAll(m.getWorktreeDir(), 0o750); err != nil {
+		if err := os.MkdirAll(m.getRepoWorktreeDir(), 0o750); err != nil {
 			return func() tea.Msg { return errMsg{err: fmt.Errorf("failed to create worktree directory: %w", err)} }
 		}
 
@@ -350,7 +350,7 @@ func (m *Model) handleCreateFromCurrentReady(msg createFromCurrentReadyMsg) tea.
 			return nil
 		}
 
-		targetPath := filepath.Join(m.getWorktreeDir(), newBranch)
+		targetPath := filepath.Join(m.getRepoWorktreeDir(), newBranch)
 		if m.worktreePathExists(targetPath) {
 			inputScr.ErrorMsg = fmt.Sprintf("Path already exists: %s", targetPath)
 			return nil
@@ -395,7 +395,7 @@ func (m *Model) handleCreateFromCurrentReady(msg createFromCurrentReadyMsg) tea.
 // executeCreateWithChanges creates a worktree and moves changes from the current worktree.
 func (m *Model) executeCreateWithChanges(wt *models.WorktreeInfo, currentBranch, newBranch, targetPath string) tea.Cmd {
 	return func() tea.Msg {
-		if err := m.ensureWorktreeDir(m.getWorktreeDir()); err != nil {
+		if err := m.ensureWorktreeDir(m.getRepoWorktreeDir()); err != nil {
 			return errMsg{err: err}
 		}
 
@@ -469,7 +469,7 @@ func (m *Model) executeCreateWithChanges(wt *models.WorktreeInfo, currentBranch,
 // executeCreateWithoutChanges creates a worktree without moving changes.
 func (m *Model) executeCreateWithoutChanges(currentBranch, newBranch, targetPath string) tea.Cmd {
 	return func() tea.Msg {
-		if err := m.ensureWorktreeDir(m.getWorktreeDir()); err != nil {
+		if err := m.ensureWorktreeDir(m.getRepoWorktreeDir()); err != nil {
 			return errMsg{err: err}
 		}
 


### PR DESCRIPTION
## Summary

Fixes #17 — TUI creates worktrees with flat layout instead of org/repo/name.

## Problem

When creating a worktree via the TUI, the path was constructed as `<worktree-dir>/<name>` (e.g. `~/.local/share/worktrees/main-clever-harbor/`) instead of the expected `<worktree-dir>/<org>/<repo>/<name>` layout (e.g. `~/.local/share/worktrees/public/home/main-clever-harbor/`).

The CLI path (`lazyworktree create`) worked correctly because it used `ResolveRepoName` to include the repo prefix.

## Root Cause

In `internal/app/worktree_operations.go`, three TUI code paths used `m.getWorktreeDir()` (base dir only) instead of `m.getRepoWorktreeDir()` (base dir + repo key):

- `showCreateFromChangesInput` — path construction and mkdir
- `handleCreateFromCurrentReady` — path construction
- `executeCreateWithChanges` / `executeCreateWithoutChanges` — `ensureWorktreeDir` calls

Other TUI code paths in `base_selection.go` and `messages.go` already used `getRepoWorktreeDir()` correctly.

## Changes

- **`internal/app/worktree_operations.go`**: Changed 5 occurrences of `m.getWorktreeDir()` → `m.getRepoWorktreeDir()`
- **`internal/app/worktree_operations_test.go`**: Added 2 tests verifying both "create from current" and "create from changes" flows construct target paths with the org/repo layout