### PR TITLE
feat: Store and apply PR info to worktrees

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -155,6 +155,7 @@ type (
 		branch     string
 		targetPath string
 		note       string
+		pr         *models.PRInfo
 		err        error
 	}
 	openIssuesLoadedMsg struct {
@@ -358,6 +359,8 @@ type Model struct {
 
 	// Post-refresh selection (e.g. after creating worktree)
 	pendingSelectWorktreePath string
+	pendingPR                 *models.PRInfo
+	pendingPRPath             string
 
 	// Trust / repo commands
 	repoConfig     *config.RepoConfig
@@ -644,9 +647,13 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.clearLoadingScreen()
 		if msg.err != nil {
 			m.pendingSelectWorktreePath = ""
+			m.pendingPR = nil
+			m.pendingPRPath = ""
 			m.showInfo(fmt.Sprintf("Failed to create worktree from PR/MR #%d: %v", msg.prNumber, msg.err), nil)
 			return m, nil
 		}
+		m.pendingPR = msg.pr
+		m.pendingPRPath = msg.targetPath
 		if strings.TrimSpace(msg.note) != "" {
 			m.setWorktreeNote(msg.targetPath, msg.note)
 		}

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -74,6 +74,24 @@ func (m *Model) handleWorktreesLoaded(msg worktreesLoadedMsg) (tea.Model, tea.Cm
 		}
 	}
 
+	// Apply pending PR metadata to the specific worktree path it was created for.
+	if m.pendingPR != nil && m.pendingPRPath != "" {
+		for _, wt := range m.state.data.worktrees {
+			if wt.Path != m.pendingPRPath {
+				continue
+			}
+			wt.PR = m.pendingPR
+			wt.PRFetchStatus = models.PRFetchStatusLoaded
+			if !m.prDataLoaded {
+				m.prDataLoaded = true
+				m.updateTableColumns(m.state.ui.worktreeTable.Width())
+			}
+			m.pendingPR = nil
+			m.pendingPRPath = ""
+			break
+		}
+	}
+
 	// Now update table with the new timestamp
 	m.updateTable()
 
@@ -470,6 +488,7 @@ func (m *Model) handleOpenPRsLoaded(msg openPRsLoadedMsg) tea.Cmd {
 				branch:     localBranch,
 				targetPath: targetPath,
 				note:       noteText,
+				pr:         pr,
 			}
 		}
 	}


### PR DESCRIPTION
Added logic to store Pull Request (PR) information when a new worktree is created from a PR. This information is then applied to the corresponding worktree upon the next refresh. This ensures that the PR details are correctly associated with the worktree, even if the application state changes before the worktree is fully loaded.

Also, the pending PR and path information is cleared on error during worktree creation.