### PR TITLE
feat: move Git Status pane to its own pane

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -263,6 +263,7 @@ const (
 
 type uiState struct {
 	worktreeTable  table.Model
+	infoViewport   viewport.Model
 	statusViewport viewport.Model
 	logTable       table.Model
 	filterInput    textinput.Model
@@ -448,6 +449,9 @@ func NewModel(cfg *config.AppConfig, initialFilter string) *Model {
 	// Don't set Foreground on Cell - let Selected style's foreground take effect
 	t.SetStyles(s)
 
+	infoVp := viewport.New(viewport.WithWidth(40), viewport.WithHeight(5))
+	infoVp.SoftWrap = true
+
 	statusVp := viewport.New(viewport.WithWidth(40), viewport.WithHeight(5))
 	statusVp.SetContent("Loading...")
 
@@ -535,6 +539,7 @@ func NewModel(cfg *config.AppConfig, initialFilter string) *Model {
 	m.cache.detailsCache = make(map[string]*detailsCacheEntry)
 
 	m.state.ui.worktreeTable = t
+	m.state.ui.infoViewport = infoVp
 	m.state.ui.statusViewport = statusVp
 	m.state.ui.logTable = logT
 	m.state.ui.filterInput = filterInput

--- a/internal/app/app_clipboard_test.go
+++ b/internal/app/app_clipboard_test.go
@@ -21,7 +21,7 @@ func TestYankContextual_Pane0_CopiesPath(t *testing.T) {
 	assert.NotNil(t, cmd, "expected a command to be returned")
 }
 
-func TestYankContextual_Pane2_CopiesSHA(t *testing.T) {
+func TestYankContextual_Pane3_CopiesSHA(t *testing.T) {
 	m := NewModel(&config.AppConfig{WorktreeDir: t.TempDir()}, "")
 	m.state.view.FocusedPane = 3
 	m.state.data.logEntries = []commitLogEntry{
@@ -32,7 +32,7 @@ func TestYankContextual_Pane2_CopiesSHA(t *testing.T) {
 	assert.NotNil(t, cmd, "expected a command to be returned")
 }
 
-func TestYankContextual_Pane1_CopiesFilePath(t *testing.T) {
+func TestYankContextual_Pane2_CopiesFilePath(t *testing.T) {
 	m := NewModel(&config.AppConfig{WorktreeDir: t.TempDir()}, "")
 	m.state.view.FocusedPane = 2
 	m.state.data.filteredWts = []*models.WorktreeInfo{

--- a/internal/app/ci.go
+++ b/internal/app/ci.go
@@ -33,7 +33,7 @@ func (m *Model) openCICheckSelection() tea.Cmd {
 	// Get CI checks from cache
 	checks, _, ok := m.cache.ciCache.Get(wt.Branch)
 	if !ok || len(checks) == 0 {
-		m.showInfo("No CI checks available. Press 'p' to fetch PR data first.", nil)
+		m.showInfo("No CI checks available. Press 'r' to refresh and fetch PR data first.", nil)
 		return nil
 	}
 

--- a/internal/app/render_components.go
+++ b/internal/app/render_components.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
-	"github.com/muesli/reflow/wrap"
 )
 
 // renderHeader renders the application header.
@@ -113,9 +112,10 @@ func (m *Model) renderFooter(layout layoutDims) string {
 			m.renderKeyHint("?", "Help"),
 		)
 
-	case 1: // Status pane (info + CI)
+	case 1: // Info pane (info + CI)
 		hints = []string{
-			m.renderKeyHint("j/k", "CI Checks"),
+			m.renderKeyHint("j/k", "Scroll"),
+			m.renderKeyHint("n/p", "CI Checks"),
 			m.renderKeyHint("Enter", "Open URL"),
 			m.renderKeyHint("Ctrl+v", "CI Logs"),
 			m.renderKeyHint("Tab", "Switch Pane"),
@@ -264,26 +264,6 @@ func (m *Model) renderPaneBlock(index int, title string, focused bool, width, he
 	finalTopBorder := styledTopLeft + styledTitleBlock + filterIndicator + zoomIndicator + styledRemaining + styledTopRight
 
 	return lipgloss.JoinVertical(lipgloss.Left, finalTopBorder, styledContent)
-}
-
-// renderInnerBox renders a bordered inner box with title and content.
-func (m *Model) renderInnerBox(title, content string, width, height int) string {
-	if content == "" {
-		content = "No data available."
-	}
-
-	titleStyle := lipgloss.NewStyle().Foreground(m.theme.MutedFg).Bold(true)
-
-	style := m.baseInnerBoxStyle().Width(width)
-	if height > 0 {
-		style = style.Height(height)
-	}
-
-	innerWidth := maxInt(1, width-style.GetHorizontalFrameSize())
-	wrappedContent := wrap.String(content, innerWidth)
-	boxContent := lipgloss.JoinVertical(lipgloss.Left, titleStyle.Render(title), wrappedContent)
-
-	return style.Render(boxContent)
 }
 
 // renderCIStatusPill renders a CI aggregate status as a powerline pill.

--- a/internal/app/screen/help.go
+++ b/internal/app/screen/help.go
@@ -64,8 +64,9 @@ func NewHelpScreen(maxWidth, maxHeight int, customCommands map[string]*config.Cu
 - Enter: Jump to selected worktree (exit and cd)
 - q: Quit application
 
-**{{HELP_STATUS_PANE}}Status Pane (when focused)**
-- j / k: Navigate CI checks (when visible)
+**{{HELP_STATUS_PANE}}Info Pane (when focused)**
+- j / k: Scroll info content
+- n / p: Navigate CI checks (when visible)
 - Enter: Open selected CI check URL in browser
 - PR number in the info panel is clickable in terminals that support OSC-8 hyperlinks
 - Ctrl+v: View selected CI check logs in pager (when CI check is selected)

--- a/internal/app/terminal_hyperlink_test.go
+++ b/internal/app/terminal_hyperlink_test.go
@@ -93,7 +93,7 @@ func TestBuildInfoContentMainBranchWithoutPRHidesFetchHint(t *testing.T) {
 	m.state.data.worktrees = []*models.WorktreeInfo{mainWt}
 
 	info := m.buildInfoContent(mainWt)
-	if strings.Contains(info, "Press 'p' to fetch PR data") {
+	if strings.Contains(info, "Press 'r' to refresh and fetch PR data") {
 		t.Fatalf("did not expect fetch hint on main branch, got %q", info)
 	}
 	if !strings.Contains(info, "Main branch usually has no PR") {
@@ -122,7 +122,7 @@ func TestBuildInfoContentFeatureBranchShowsFetchHint(t *testing.T) {
 	m.state.data.worktrees = []*models.WorktreeInfo{mainWt, featureWt}
 
 	info := m.buildInfoContent(featureWt)
-	if !strings.Contains(info, "Press 'p' to fetch PR data") {
+	if !strings.Contains(info, "Press 'r' to refresh and fetch PR data") {
 		t.Fatalf("expected fetch hint for feature branch, got %q", info)
 	}
 }


### PR DESCRIPTION
This commit introduces significant changes to how the application's layout and pane management are handled. Key changes include:

* **Pane restructuring:** The right-hand side of the layout has been expanded from two panes (Status and Log) to three (Status, Git Status, and Commit). This allows for more granular display of information.
* **Layout mode updates:** The `LayoutTop` mode has been adjusted to accommodate the new three-pane structure on the bottom.
* **Navigation adjustments:** Navigation keys and logic have been updated to account for the new pane index and layout changes.
* **Clipboard and Search/Filter updates:** Clipboard actions, search, and filter targets have been modified to correctly map to the new Git Status pane.
* **README and documentation updates:** The README has been updated to reflect the new keybindings and pane descriptions, and corresponding tests have been adjusted.
* **Test suite updates:** Numerous tests have been refactored to align with the new pane indexing and layout logic.

These changes provide a more organized and extensible interface for managing Git information.