### PR TITLE
feat: support repo-local worktree placement via $LWT_REPO_PATH

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -2,7 +2,13 @@
 # CORE SETTINGS
 # ============================================================================
 
-# Directory where your worktrees will be created
+# Directory where your worktrees will be created.
+# lazyworktree automatically sets $LWT_REPO_PATH to the git repository root,
+# so you can place worktrees inside the repository itself:
+#   worktree_dir: $LWT_REPO_PATH/.worktrees
+# In repo-local mode the <repoName> path segment is omitted, giving:
+#   <repoRoot>/.worktrees/<worktreeName>
+# Remember to add the directory to .gitignore (e.g. echo '.worktrees' >> .gitignore).
 worktree_dir: ~/.local/share/worktrees
 
 # How worktrees are sorted in the list

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,6 +2,20 @@
 
 Default worktree location: `~/.local/share/worktrees/<organization>-<repo_name>`.
 
+To keep worktrees inside the repository itself, set `worktree_dir` to use `$LWT_REPO_PATH` — lazyworktree automatically exports this variable to the git repository root before loading config:
+
+```bash
+git config --local lw.worktree-dir '$LWT_REPO_PATH/.worktrees'
+```
+
+Worktrees are then created at `<repoRoot>/.worktrees/<worktreeName>` (the `<repoName>` segment is omitted when the directory is already inside the repository).
+
+Add the directory to `.gitignore` so it does not appear in `git status`:
+
+```bash
+echo '.worktrees' >> .gitignore
+```
+
 <div class="lw-callout">
   <p><strong>Find settings quickly:</strong> use the map below, then jump to the relevant settings group.</p>
 </div>
@@ -101,12 +115,13 @@ Use the `lw.` prefix:
 ```bash
 # Set globally
 git config --global lw.theme nord
-git config --global lw.worktree_dir ~/.local/share/worktrees
+git config --global lw.worktree-dir ~/.local/share/worktrees
 
 # Set per-repository
 git config --local lw.theme dracula
-git config --local lw.init_commands "link_topsymlinks"
-git config --local lw.init_commands "npm install"  # Multi-values supported
+git config --local lw.worktree-dir '$LWT_REPO_PATH/.worktrees'  # Repo-local worktrees
+git config --local lw.init-commands "link_topsymlinks"
+git config --local lw.init-commands "npm install"  # Multi-values supported
 ```
 
 To view configured values:

--- a/docs/configuration/overview.md
+++ b/docs/configuration/overview.md
@@ -32,7 +32,7 @@ Use `lw.` keys:
 
 ```bash
 git config --global lw.theme nord
-git config --local lw.sort_mode switched
+git config --local lw.sort-mode switched
 ```
 
 List configured keys:

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -5,7 +5,7 @@ This page is generated from `internal/config/config.go`. Run `make docs-sync` af
 <!-- BEGIN GENERATED:config-reference -->
 | Key | Type | Default | Description |
 | --- | --- | --- | --- |
-| `worktree_dir` | `string` | `none` | Root directory for managed worktrees. |
+| `worktree_dir` | `string` | `none` | Root directory for managed worktrees. Supports `$LWT_REPO_PATH` (auto-set to the git repository root) for repo-local placement, e.g. `$LWT_REPO_PATH/.worktrees`. When the directory is inside the repository, the `<repoName>` path segment is omitted automatically. |
 | `theme` | `string` | `auto-detect` | UI theme selection. |
 | `icon_set` | `enum(nerd-font-v3\|text)` | `nerd-font-v3` | Icon rendering mode for terminal compatibility. |
 | `layout` | `enum(default\|top)` | `default` | Pane layout strategy. |

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
-	github.com/charmbracelet/ultraviolet v0.0.0-20260422141423-a0f1f21775f7 // indirect
+	github.com/charmbracelet/ultraviolet v0.0.0-20260416161146-9c68a866306c // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/charmbracelet/colorprofile v0.4.3 h1:QPa1IWkYI+AOB+fE+mg/5/4HRMZcaXex
 github.com/charmbracelet/colorprofile v0.4.3/go.mod h1:/zT4BhpD5aGFpqQQqw7a+VtHCzu+zrQtt1zhMt9mR4Q=
 github.com/charmbracelet/lipgloss v1.1.0 h1:vYXsiLHVkK7fp74RkV7b2kq9+zDLoEU4MZoFqR/noCY=
 github.com/charmbracelet/lipgloss v1.1.0/go.mod h1:/6Q8FR2o+kj8rz4Dq0zQc3vYf7X+B0binUUBwA0aL30=
-github.com/charmbracelet/ultraviolet v0.0.0-20260422141423-a0f1f21775f7 h1:PeRlqWGEoO0apcS62iEgxQhVnFCTOYyQvi2sUTdf6IE=
-github.com/charmbracelet/ultraviolet v0.0.0-20260422141423-a0f1f21775f7/go.mod h1:3YdTxlnV/L0bQ3VN8WOSw8doF7LZV/xawUQ4MuAPDvo=
+github.com/charmbracelet/ultraviolet v0.0.0-20260416161146-9c68a866306c h1:a+Q3cOt8vEb6ETG/st32Qjm8R5fdI9wSKb3tqPISnoY=
+github.com/charmbracelet/ultraviolet v0.0.0-20260416161146-9c68a866306c/go.mod h1:bAAz7dh/FTYfC+oiHavL4mX1tOIBZ0ZwYjSi3qE6ivM=
 github.com/charmbracelet/x/ansi v0.11.7 h1:kzv1kJvjg2S3r9KHo8hDdHFQLEqn4RBCb39dAYC84jI=
 github.com/charmbracelet/x/ansi v0.11.7/go.mod h1:9qGpnAVYz+8ACONkZBUWPtL7lulP9No6p1epAihUZwQ=
 github.com/charmbracelet/x/cellbuf v0.0.15 h1:ur3pZy0o6z/R7EylET877CBxaiE1Sp1GMxoFPAIztPI=

--- a/hack/docsync/main.go
+++ b/hack/docsync/main.go
@@ -365,7 +365,7 @@ func parseConfigKeys(path string) ([]configKeySpec, error) {
 	}
 
 	descByKey := map[string]string{
-		"worktree_dir":                 "Root directory for managed worktrees.",
+		"worktree_dir":                 "Root directory for managed worktrees. Supports `$LWT_REPO_PATH` (auto-set to the git repository root) for repo-local placement, e.g. `$LWT_REPO_PATH/.worktrees`. When the directory is inside the repository, the `<repoName>` path segment is omitted automatically.",
 		"debug_log":                    "Debug log file path.",
 		"pager":                        "Pager for command output views.",
 		"ci_script_pager":              "Dedicated pager for CI logs.",

--- a/internal/app/app_helpers.go
+++ b/internal/app/app_helpers.go
@@ -13,6 +13,7 @@ import (
 	"charm.land/lipgloss/v2"
 	appscreen "github.com/chmouel/lazyworktree/internal/app/screen"
 	"github.com/chmouel/lazyworktree/internal/app/services"
+	"github.com/chmouel/lazyworktree/internal/cli"
 	log "github.com/chmouel/lazyworktree/internal/log"
 	"github.com/chmouel/lazyworktree/internal/models"
 	"github.com/chmouel/lazyworktree/internal/utils"
@@ -396,7 +397,14 @@ func (m *Model) getWorktreeDir() string {
 }
 
 func (m *Model) getRepoWorktreeDir() string {
-	return filepath.Join(m.getWorktreeDir(), m.getRepoKey())
+	dir := m.getWorktreeDir()
+	if m.state.services.git != nil {
+		mainPath := m.state.services.git.GetMainWorktreePath(m.ctx)
+		if cli.IsRepoLocal(dir, mainPath) {
+			return dir
+		}
+	}
+	return filepath.Join(dir, m.getRepoKey())
 }
 
 // normalizePath returns a canonical path for comparison.

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -5,10 +5,12 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"slices"
 	"sort"
 	"strings"
+	"sync"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/chmouel/lazyworktree/internal/app"
@@ -19,6 +21,29 @@ import (
 	"github.com/chmouel/lazyworktree/internal/utils"
 	"github.com/urfave/cli/v3"
 )
+
+// gitToplevel returns the root of the current git repository, or "" if not in one.
+func gitToplevel() string {
+	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+var initRepoPathOnce sync.Once
+
+// ensureRepoPath sets $LWT_REPO_PATH lazily so the git probe only runs when
+// config is actually loaded (skipped for --version, shell completion, etc.).
+func ensureRepoPath() {
+	initRepoPathOnce.Do(func() {
+		if root := gitToplevel(); root != "" {
+			_ = os.Setenv("LWT_REPO_PATH", root)
+		} else {
+			_ = os.Unsetenv("LWT_REPO_PATH")
+		}
+	})
+}
 
 // Run constructs the CLI application and executes it.
 // It returns an exit code suitable for os.Exit.
@@ -90,6 +115,8 @@ func Run(args []string) int {
 }
 
 func runTUI(_ context.Context, cmd *cli.Command) error {
+	ensureRepoPath()
+
 	if debugLog := cmd.String("debug-log"); debugLog != "" {
 		expanded, err := utils.ExpandPath(debugLog)
 		if err == nil {

--- a/internal/bootstrap/commands.go
+++ b/internal/bootstrap/commands.go
@@ -1174,7 +1174,7 @@ func handleDeleteAction(ctx context.Context, cmd *appiCli.Command) error {
 					nonMain = append(nonMain, wt)
 				}
 			}
-			if target, fErr := cli.FindWorktreeByPathOrName(worktreePath, nonMain, cfg.WorktreeDir, repoKey); fErr == nil {
+			if target, fErr := cli.FindWorktreeByPathOrName(worktreePath, nonMain, cfg.WorktreeDir, repoKey, gitSvc.GetMainWorktreePath(ctx)); fErr == nil {
 				preDeleteName = filepath.Base(target.Path)
 				preDeletePath = target.Path
 				willDeleteBranch = deleteBranch && preDeleteName == target.Branch
@@ -1260,7 +1260,7 @@ func handleRenameAction(ctx context.Context, cmd *appiCli.Command) error {
 					nonMain = append(nonMain, wt)
 				}
 			}
-			if target, fErr := cli.FindWorktreeByPathOrName(worktreePath, nonMain, cfg.WorktreeDir, repoKey); fErr == nil {
+			if target, fErr := cli.FindWorktreeByPathOrName(worktreePath, nonMain, cfg.WorktreeDir, repoKey, gitSvc.GetMainWorktreePath(ctx)); fErr == nil {
 				oldName = filepath.Base(target.Path)
 				oldPath = target.Path
 				sanitizedNewName = utils.SanitizeBranchName(newName, 100)
@@ -1521,7 +1521,7 @@ func handleExecAction(ctx context.Context, cmd *appiCli.Command) error {
 	var targetWorktree *models.WorktreeInfo
 	if workspace != "" {
 		// User provided workspace flag
-		targetWorktree, err = cli.FindWorktreeByPathOrName(workspace, worktrees, cfg.WorktreeDir, gitSvc.ResolveRepoName(ctx))
+		targetWorktree, err = cli.FindWorktreeByPathOrName(workspace, worktrees, cfg.WorktreeDir, gitSvc.ResolveRepoName(ctx), gitSvc.GetMainWorktreePath(ctx))
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			return err

--- a/internal/bootstrap/subcommands.go
+++ b/internal/bootstrap/subcommands.go
@@ -10,6 +10,8 @@ import (
 
 // loadCLIConfig loads and configures the application configuration for CLI mode.
 func loadCLIConfig(configFileFlag, worktreeDirFlag string, configOverrides []string) (*config.AppConfig, error) {
+	ensureRepoPath()
+
 	cfg, err := config.LoadConfig(configFileFlag)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error loading config: %v\n", err)

--- a/internal/cli/operations.go
+++ b/internal/cli/operations.go
@@ -61,6 +61,27 @@ type gitService interface {
 
 var _ gitService = (*git.Service)(nil)
 
+// IsRepoLocal reports whether worktreeDir is inside mainWorktreePath,
+// indicating that worktrees are stored within the repository itself.
+func IsRepoLocal(worktreeDir, mainWorktreePath string) bool {
+	if mainWorktreePath == "" || worktreeDir == "" {
+		return false
+	}
+	return strings.HasPrefix(filepath.Clean(worktreeDir)+string(filepath.Separator),
+		filepath.Clean(mainWorktreePath)+string(filepath.Separator))
+}
+
+// resolveWorktreeBaseDir returns the parent directory for a new worktree.
+// When worktreeDir is already inside mainWorktreePath (repo-local mode), the
+// repoName segment is omitted — the dir is already scoped to one repo.
+// Otherwise the classic <worktreeDir>/<repoName> structure is used.
+func resolveWorktreeBaseDir(worktreeDir, mainWorktreePath, repoName string) string {
+	if IsRepoLocal(worktreeDir, mainWorktreePath) {
+		return worktreeDir
+	}
+	return filepath.Join(worktreeDir, repoName)
+}
+
 // CreateFromBranch creates a worktree from a branch name.
 func CreateFromBranch(ctx context.Context, gitSvc gitService, cfg *config.AppConfig, branchName, worktreeName string, withChange, silent bool) (string, error) {
 	return CreateFromBranchWithFS(ctx, gitSvc, cfg, branchName, worktreeName, withChange, silent, DefaultFS)
@@ -92,13 +113,14 @@ func CreateFromBranchWithFS(ctx context.Context, gitSvc gitService, cfg *config.
 	}
 
 	// Construct target path based on worktree name
+	mainWorktreePath := gitSvc.GetMainWorktreePath(ctx)
 	repoName := gitSvc.ResolveRepoName(ctx)
 
 	// Generate random name if not provided, or validate user-provided name
 	if worktreeName == "" {
 		// Generate random name with retry for uniqueness
 		sanitizedBranch := utils.SanitizeBranchName(branchName, 50)
-		worktreeName = generateUniqueWorktreeNameFS(cfg, repoName, sanitizedBranch, fs)
+		worktreeName = generateUniqueWorktreeNameFS(cfg, mainWorktreePath, repoName, sanitizedBranch, fs)
 	} else {
 		// Validate and sanitise user-provided name
 		sanitised := utils.SanitizeBranchName(worktreeName, 100)
@@ -108,7 +130,8 @@ func CreateFromBranchWithFS(ctx context.Context, gitSvc gitService, cfg *config.
 		worktreeName = sanitised
 	}
 
-	targetPath := filepath.Join(cfg.WorktreeDir, repoName, worktreeName)
+	base := resolveWorktreeBaseDir(cfg.WorktreeDir, mainWorktreePath, repoName)
+	targetPath := filepath.Join(base, worktreeName)
 
 	// Check for path conflicts
 	if _, err := fs.Stat(targetPath); err == nil {
@@ -190,13 +213,14 @@ func createWorktreeFromBranch(ctx context.Context, gitSvc gitService, cfg *confi
 // generateUniqueWorktreeNameFS generates a unique worktree name with retries.
 // Format: <branch>-<random-adjective>-<random-noun>
 // Retries up to 10 times if path already exists.
-func generateUniqueWorktreeNameFS(cfg *config.AppConfig, repoName, branchName string, fs OSFilesystem) string {
+func generateUniqueWorktreeNameFS(cfg *config.AppConfig, mainWorktreePath, repoName, branchName string, fs OSFilesystem) string {
 	const maxRetries = 10
 
+	base := resolveWorktreeBaseDir(cfg.WorktreeDir, mainWorktreePath, repoName)
 	for range maxRetries {
 		randomPart := utils.RandomBranchName()
 		candidate := fmt.Sprintf("%s-%s", branchName, randomPart)
-		targetPath := filepath.Join(cfg.WorktreeDir, repoName, candidate)
+		targetPath := filepath.Join(base, candidate)
 
 		// Check if path exists
 		if _, err := fs.Stat(targetPath); os.IsNotExist(err) {
@@ -261,6 +285,7 @@ func CreateFromPRWithFS(ctx context.Context, gitSvc gitService, cfg *config.AppC
 		return "", fmt.Errorf("branch %q is already checked out in worktree %q", localBranch, worktreePath)
 	}
 
+	mainWorktreePath := gitSvc.GetMainWorktreePath(ctx)
 	repoName := gitSvc.ResolveRepoName(ctx)
 
 	if noWorkspace {
@@ -271,7 +296,8 @@ func CreateFromPRWithFS(ctx context.Context, gitSvc gitService, cfg *config.AppC
 	}
 
 	// Construct target path
-	targetPath := filepath.Join(cfg.WorktreeDir, repoName, worktreeName)
+	base := resolveWorktreeBaseDir(cfg.WorktreeDir, mainWorktreePath, repoName)
+	targetPath := filepath.Join(base, worktreeName)
 
 	// Check for path conflicts
 	if _, err := fs.Stat(targetPath); err == nil {
@@ -390,8 +416,10 @@ func CreateFromIssueWithFS(ctx context.Context, gitSvc gitService, cfg *config.A
 	}
 
 	// Construct target path
+	mainWorktreePath := gitSvc.GetMainWorktreePath(ctx)
 	repoName := gitSvc.ResolveRepoName(ctx)
-	targetPath := filepath.Join(cfg.WorktreeDir, repoName, branchName)
+	base := resolveWorktreeBaseDir(cfg.WorktreeDir, mainWorktreePath, repoName)
+	targetPath := filepath.Join(base, branchName)
 
 	// Check for path conflicts
 	if _, err := fs.Stat(targetPath); err == nil {
@@ -456,7 +484,7 @@ func DeleteWorktree(ctx context.Context, gitSvc gitService, cfg *config.AppConfi
 	}
 
 	// Find the worktree to delete
-	selectedWorktree, err := FindWorktreeByPathOrName(worktreePath, nonMainWorktrees, cfg.WorktreeDir, gitSvc.ResolveRepoName(ctx))
+	selectedWorktree, err := FindWorktreeByPathOrName(worktreePath, nonMainWorktrees, cfg.WorktreeDir, gitSvc.ResolveRepoName(ctx), gitSvc.GetMainWorktreePath(ctx))
 	if err != nil {
 		return err
 	}
@@ -538,7 +566,7 @@ func RenameWorktree(ctx context.Context, gitSvc gitService, cfg *config.AppConfi
 		return fmt.Errorf("invalid new name: must contain at least one alphanumeric character")
 	}
 
-	selectedWorktree, err := FindWorktreeByPathOrName(worktreePath, nonMainWorktrees, cfg.WorktreeDir, gitSvc.ResolveRepoName(ctx))
+	selectedWorktree, err := FindWorktreeByPathOrName(worktreePath, nonMainWorktrees, cfg.WorktreeDir, gitSvc.ResolveRepoName(ctx), gitSvc.GetMainWorktreePath(ctx))
 	if err != nil {
 		return err
 	}
@@ -567,7 +595,7 @@ func RenameWorktree(ctx context.Context, gitSvc gitService, cfg *config.AppConfi
 }
 
 // FindWorktreeByPathOrName finds a worktree by its path or name.
-func FindWorktreeByPathOrName(pathOrName string, worktrees []*models.WorktreeInfo, worktreeDir, repoName string) (*models.WorktreeInfo, error) {
+func FindWorktreeByPathOrName(pathOrName string, worktrees []*models.WorktreeInfo, worktreeDir, repoName, mainWorktreePath string) (*models.WorktreeInfo, error) {
 	// Try to match by exact path
 	for _, wt := range worktrees {
 		if wt.Path == pathOrName {
@@ -589,8 +617,8 @@ func FindWorktreeByPathOrName(pathOrName string, worktrees []*models.WorktreeInf
 		}
 	}
 
-	// Try to construct the path from worktree name and match
-	constructedPath := filepath.Join(worktreeDir, repoName, pathOrName)
+	// Try to construct the path from worktree name and match (handles both global and repo-local modes)
+	constructedPath := filepath.Join(resolveWorktreeBaseDir(worktreeDir, mainWorktreePath, repoName), pathOrName)
 	for _, wt := range worktrees {
 		if wt.Path == constructedPath {
 			return wt, nil
@@ -922,7 +950,7 @@ func resolveNoteContext(ctx context.Context, gitSvc gitService, cfg *config.AppC
 		}
 	} else {
 		repoName := gitSvc.ResolveRepoName(ctx)
-		target, err = FindWorktreeByPathOrName(worktreePathOrName, worktrees, cfg.WorktreeDir, repoName)
+		target, err = FindWorktreeByPathOrName(worktreePathOrName, worktrees, cfg.WorktreeDir, repoName, gitSvc.GetMainWorktreePath(ctx))
 		if err != nil {
 			return nil, err
 		}

--- a/internal/cli/operations_test.go
+++ b/internal/cli/operations_test.go
@@ -221,7 +221,7 @@ func TestFindWorktreeByPathOrName(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			found, err := FindWorktreeByPathOrName(tt.pathOrName, worktrees, worktreeDir, repoName)
+			found, err := FindWorktreeByPathOrName(tt.pathOrName, worktrees, worktreeDir, repoName, "")
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("expected error")
@@ -236,6 +236,142 @@ func TestFindWorktreeByPathOrName(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolveWorktreeBaseDir(t *testing.T) {
+	t.Parallel()
+
+	globalWorktreeDir := filepath.Join(string(filepath.Separator), "home", "user", ".local", "share", "worktrees")
+	mainWorktreePath := filepath.Join(string(filepath.Separator), "home", "user", "code", "myrepo")
+	repoLocalWorktreeDir := filepath.Join(mainWorktreePath, ".worktrees")
+	worktreesRootDir := filepath.Join(string(filepath.Separator), "worktrees")
+	similarPrefixWorktreeDir := filepath.Join(string(filepath.Separator), "home", "user", "code", "myrepo-other", ".worktrees")
+
+	tests := []struct {
+		name             string
+		worktreeDir      string
+		mainWorktreePath string
+		repoName         string
+		want             string
+	}{
+		{
+			name:             "global mode: absolute dir outside repo",
+			worktreeDir:      globalWorktreeDir,
+			mainWorktreePath: mainWorktreePath,
+			repoName:         "org-myrepo",
+			want:             filepath.Join(globalWorktreeDir, "org-myrepo"),
+		},
+		{
+			name:             "repo-local mode: dir inside main worktree",
+			worktreeDir:      repoLocalWorktreeDir,
+			mainWorktreePath: mainWorktreePath,
+			repoName:         "org-myrepo",
+			want:             repoLocalWorktreeDir,
+		},
+		{
+			name:             "repo-local mode: dir equals main worktree path",
+			worktreeDir:      mainWorktreePath,
+			mainWorktreePath: mainWorktreePath,
+			repoName:         "org-myrepo",
+			want:             mainWorktreePath,
+		},
+		{
+			name:             "empty mainWorktreePath falls back to global",
+			worktreeDir:      worktreesRootDir,
+			mainWorktreePath: "",
+			repoName:         "myrepo",
+			want:             filepath.Join(worktreesRootDir, "myrepo"),
+		},
+		{
+			name:             "similar prefix does not trigger repo-local",
+			worktreeDir:      similarPrefixWorktreeDir,
+			mainWorktreePath: mainWorktreePath,
+			repoName:         "org-myrepo",
+			want:             filepath.Join(similarPrefixWorktreeDir, "org-myrepo"),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := resolveWorktreeBaseDir(tt.worktreeDir, tt.mainWorktreePath, tt.repoName)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIsRepoLocal(t *testing.T) {
+	t.Parallel()
+
+	mainWorktreePath := filepath.Join(string(filepath.Separator), "home", "user", "code", "myrepo")
+
+	tests := []struct {
+		name             string
+		worktreeDir      string
+		mainWorktreePath string
+		want             bool
+	}{
+		{
+			name:             "inside main worktree",
+			worktreeDir:      filepath.Join(mainWorktreePath, ".worktrees"),
+			mainWorktreePath: mainWorktreePath,
+			want:             true,
+		},
+		{
+			name:             "equals main worktree path",
+			worktreeDir:      mainWorktreePath,
+			mainWorktreePath: mainWorktreePath,
+			want:             true,
+		},
+		{
+			name:             "outside main worktree",
+			worktreeDir:      filepath.Join(string(filepath.Separator), "home", "user", ".local", "share", "worktrees"),
+			mainWorktreePath: mainWorktreePath,
+			want:             false,
+		},
+		{
+			name:             "similar prefix is not repo-local",
+			worktreeDir:      filepath.Join(string(filepath.Separator), "home", "user", "code", "myrepo-other", ".worktrees"),
+			mainWorktreePath: mainWorktreePath,
+			want:             false,
+		},
+		{
+			name:             "empty mainWorktreePath",
+			worktreeDir:      filepath.Join(string(filepath.Separator), "worktrees"),
+			mainWorktreePath: "",
+			want:             false,
+		},
+		{
+			name:             "empty worktreeDir",
+			worktreeDir:      "",
+			mainWorktreePath: mainWorktreePath,
+			want:             false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := IsRepoLocal(tt.worktreeDir, tt.mainWorktreePath)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestFindWorktreeByPathOrNameRepoLocal(t *testing.T) {
+	t.Parallel()
+
+	mainPath := filepath.Join(string(filepath.Separator), "home", "user", "code", "myrepo")
+	worktreeDir := filepath.Join(mainPath, ".worktrees")
+	repoName := "org-myrepo"
+
+	wtFeature := &models.WorktreeInfo{Path: filepath.Join(worktreeDir, "feature"), Branch: "feature"}
+	worktrees := []*models.WorktreeInfo{wtFeature}
+
+	found, err := FindWorktreeByPathOrName("feature", worktrees, worktreeDir, repoName, mainPath)
+	require.NoError(t, err)
+	assert.Equal(t, wtFeature, found)
 }
 
 func TestBranchExists(t *testing.T) {

--- a/internal/config/gitconfig.go
+++ b/internal/config/gitconfig.go
@@ -54,7 +54,7 @@ func parseGitConfigOutput(output string) (map[string][]string, error) {
 			continue
 		}
 
-		key := strings.TrimPrefix(parts[0], "lw.")
+		key := strings.ReplaceAll(strings.TrimPrefix(parts[0], "lw."), "-", "_")
 		value := parts[1]
 
 		// Git config can have multi-values for same key
@@ -111,13 +111,11 @@ func convertGitConfigToParseConfig(gitCfg map[string][]string) map[string]any {
 
 // loadGitConfig reads git config values and returns map for parseConfig.
 func loadGitConfig(globalOnly bool, repoPath string) (map[string]any, error) {
-	args := []string{"config", "--get-regexp", "^lw\\."}
-
+	scope := "--local"
 	if globalOnly {
-		args = append(args, "--global")
-	} else {
-		args = append(args, "--local")
+		scope = "--global"
 	}
+	args := []string{"config", scope, "--get-regexp", "^lw\\."}
 
 	output, err := runGitConfig(args, repoPath)
 	if err != nil {
@@ -182,7 +180,7 @@ func parseCLIConfigOverrides(overrides []string) (map[string]any, error) {
 			return nil, fmt.Errorf("config override key must start with 'lw.': %q", fullKey)
 		}
 
-		key := strings.TrimPrefix(fullKey, "lw.")
+		key := strings.ReplaceAll(strings.TrimPrefix(fullKey, "lw."), "-", "_")
 		if key == "" {
 			return nil, fmt.Errorf("empty config key in override: %q", override)
 		}

--- a/internal/config/gitconfig_test.go
+++ b/internal/config/gitconfig_test.go
@@ -59,6 +59,17 @@ lw.editor code --wait`,
 			expected: map[string][]string{},
 		},
 		{
+			name: "hyphens normalised to underscores",
+			output: `lw.worktree-dir /path/to/dir
+lw.auto-fetch-prs true
+lw.init-commands npm install`,
+			expected: map[string][]string{
+				"worktree_dir":   {"/path/to/dir"},
+				"auto_fetch_prs": {"true"},
+				"init_commands":  {"npm install"},
+			},
+		},
+		{
 			name: "mixed valid and empty lines",
 			output: `lw.theme nord
 
@@ -238,6 +249,14 @@ func TestParseCLIConfigOverrides(t *testing.T) {
 			overrides: []string{"lw.=value"},
 			wantErr:   true,
 			errMsg:    "empty config key",
+		},
+		{
+			name:      "hyphenated keys normalised",
+			overrides: []string{"lw.worktree-dir=/path", "lw.auto-fetch-prs=true"},
+			expected: map[string]any{
+				"worktree_dir":   "/path",
+				"auto_fetch_prs": "true",
+			},
 		},
 		{
 			name:      "empty value is allowed",

--- a/lazyworktree.1
+++ b/lazyworktree.1
@@ -66,6 +66,12 @@ Metadata Menu: Press \fBe\fR in the worktree pane to edit the selected worktree'
 Override the default worktree root directory.
 .br
 Default: ~/.local/share/worktrees
+.br
+\fB$LWT_REPO_PATH\fR is automatically set to the git repository root, enabling
+repo-local placement: \fI$LWT_REPO_PATH/.worktrees\fR. When the directory is
+inside the repository, the \fI<repoName>\fR segment is omitted so worktrees
+land directly under the configured directory. Add the directory to
+\fI.gitignore\fR so it does not appear in \fBgit status\fR.
 .
 .TP
 .B \-\-theme \fINAME\fR
@@ -1010,12 +1016,13 @@ Settings can be stored in Git's configuration system with the \fBlw.\fR prefix:
 .nf
 # Set globally
 git config --global lw.theme nord
-git config --global lw.worktree_dir ~/.local/share/worktrees
+git config --global lw.worktree-dir ~/.local/share/worktrees
 
 # Set per-repository (overrides global)
 git config --local lw.theme dracula
-git config --local lw.init_commands "link_topsymlinks"
-git config --local lw.init_commands "npm install"  # Multi-values supported
+git config --local lw.worktree-dir '$LWT_REPO_PATH/.worktrees'  # Repo-local worktrees
+git config --local lw.init-commands "link_topsymlinks"
+git config --local lw.init-commands "npm install"  # Multi-values supported
 
 # View all lazyworktree settings
 git config --global --get-regexp "^lw\."


### PR DESCRIPTION
## Summary

- Injects `$LWT_REPO_PATH` (the git repository root) into the process environment before config is loaded, so the existing `ExpandPath` / `os.ExpandEnv` machinery expands it transparently
- Users can store worktrees inside their project with a single git config line:
  ```bash
  git config --local lw.worktree_dir '$LWT_REPO_PATH/.worktrees'
  ```
- When the resolved `worktree_dir` is a subdirectory of the main worktree, the redundant `<repoName>` path segment is omitted automatically — worktrees land at `<repoRoot>/.worktrees/<worktreeName>` rather than `<repoRoot>/.worktrees/<repoName>/<worktreeName>`
- Global absolute paths (`~/.local/share/worktrees/…`) are completely unchanged

Closes #46.
