### PR TITLE
fix: decode URL-encoded characters in resolved repo names

### DIFF
--- a/internal/git/service_host.go
+++ b/internal/git/service_host.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"regexp"
 	"strings"
 )
@@ -104,7 +105,11 @@ func (s *Service) ResolveRepoName(ctx context.Context) string {
 		return "unknown"
 	}
 
-	return strings.TrimSuffix(repoName, ".git")
+	repoName = strings.TrimSuffix(repoName, ".git")
+	if decoded, err := url.PathUnescape(repoName); err == nil {
+		repoName = decoded
+	}
+	return repoName
 }
 
 // localRepoKey builds a stable, compact cache key when no remote name is available.

--- a/internal/git/service_host_test.go
+++ b/internal/git/service_host_test.go
@@ -127,6 +127,29 @@ func TestResolveRepoName(t *testing.T) {
 		assert.Equal(t, "owner/repo", service.ResolveRepoName(context.Background()))
 	})
 
+	t.Run("url-encoded remote segments are decoded", func(t *testing.T) {
+		cases := []struct {
+			name   string
+			remote string
+			want   string
+		}{
+			{name: "space in org", remote: "https://gitea.example.com/Company%20A/myrepo.git", want: "Company A/myrepo"},
+			{name: "encoded slash in github org", remote: "https://github.com/org%2Fname/repo.git", want: "org/name/repo"},
+			{name: "no encoding", remote: "git@github.com:owner/repo.git", want: "owner/repo"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				repo := t.TempDir()
+				runGit(t, repo, "init")
+				runGit(t, repo, "remote", "add", "origin", tc.remote)
+				withCwd(t, repo)
+
+				service := NewService(func(string, string) {}, func(string, string, string) {})
+				assert.Equal(t, tc.want, service.ResolveRepoName(context.Background()))
+			})
+		}
+	})
+
 	t.Run("resolve local key when no remote is configured", func(t *testing.T) {
 		tmpDir := t.TempDir()
 


### PR DESCRIPTION
## Summary
- Applied `url.PathUnescape()` to the return value of `ResolveRepoName()` so that URL-encoded org/repo segments (e.g., `Company%20A`) are decoded before being used in worktree directory paths.
- Added table-driven tests covering encoded spaces, encoded slashes, and plain remote URLs.

Closes #49

## Test plan
- [x] `go test -run TestResolveRepoName -v ./internal/git/` — all pass
- [x] `make sanity` — 0 issues
