### PR TITLE
fail fast on push/sync auth prompts

### DIFF
--- a/internal/app/app_helpers.go
+++ b/internal/app/app_helpers.go
@@ -76,6 +76,28 @@ func envMapToList(env map[string]string) []string {
 	return services.EnvMapToList(env)
 }
 
+// filterEnvVars filters out environment variables by name.
+func filterEnvVars(environ []string, excluded ...string) []string {
+	if len(excluded) == 0 {
+		return append([]string{}, environ...)
+	}
+
+	excludedSet := make(map[string]struct{}, len(excluded))
+	for _, key := range excluded {
+		excludedSet[key] = struct{}{}
+	}
+
+	filtered := make([]string, 0, len(environ))
+	for _, entry := range environ {
+		parts := strings.SplitN(entry, "=", 2)
+		if _, skip := excludedSet[parts[0]]; skip {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
+}
+
 // filterWorktreeEnvVars filters out worktree-specific environment variables
 // to prevent duplicates when building command environments.
 func filterWorktreeEnvVars(environ []string) []string {
@@ -95,6 +117,35 @@ func filterWorktreeEnvVars(environ []string) []string {
 		}
 	}
 	return filtered
+}
+
+func nonInteractiveSSHCommand(existing, fallback string) string {
+	const batchModeFlag = "-oBatchMode=yes"
+
+	command := strings.TrimSpace(existing)
+	if command == "" {
+		fallback = strings.TrimSpace(fallback)
+		if fallback != "" {
+			command = shellQuote(fallback)
+		} else {
+			command = "ssh"
+		}
+	}
+	if strings.Contains(command, batchModeFlag) {
+		return command
+	}
+	return command + " " + batchModeFlag
+}
+
+func (m *Model) buildNonInteractiveGitEnv(branch, wtPath string) []string {
+	envVars := filterWorktreeEnvVars(os.Environ())
+	envVars = filterEnvVars(envVars, "GIT_TERMINAL_PROMPT", "GIT_SSH_COMMAND")
+	envVars = append(envVars, envMapToList(m.buildCommandEnv(branch, wtPath))...)
+	envVars = append(envVars,
+		"GIT_TERMINAL_PROMPT=0",
+		fmt.Sprintf("GIT_SSH_COMMAND=%s", nonInteractiveSSHCommand(os.Getenv("GIT_SSH_COMMAND"), os.Getenv("GIT_SSH"))),
+	)
+	return envVars
 }
 
 // isEscKey checks if the key string represents an escape key.

--- a/internal/app/app_helpers_test.go
+++ b/internal/app/app_helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/chmouel/lazyworktree/internal/config"
@@ -190,6 +191,118 @@ func TestFilterWorktreeEnvVars(t *testing.T) {
 				t.Errorf("filterWorktreeEnvVars() = %v, want %v", result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestFilterEnvVars(t *testing.T) {
+	input := []string{
+		"PATH=/usr/bin",
+		"GIT_TERMINAL_PROMPT=1",
+		"GIT_SSH_COMMAND=ssh -F ~/.ssh/config",
+		"HOME=/home/user",
+	}
+
+	got := filterEnvVars(input, "GIT_TERMINAL_PROMPT", "GIT_SSH_COMMAND")
+	want := []string{
+		"PATH=/usr/bin",
+		"HOME=/home/user",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("filterEnvVars() = %v, want %v", got, want)
+	}
+}
+
+func TestNonInteractiveSSHCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing string
+		fallback string
+		want     string
+	}{
+		{
+			name:     "defaults to batch mode ssh",
+			existing: "",
+			fallback: "",
+			want:     "ssh -oBatchMode=yes",
+		},
+		{
+			name:     "appends batch mode when missing",
+			existing: "ssh -F ~/.ssh/config",
+			fallback: "",
+			want:     "ssh -F ~/.ssh/config -oBatchMode=yes",
+		},
+		{
+			name:     "keeps existing batch mode",
+			existing: "ssh -F ~/.ssh/config -oBatchMode=yes",
+			fallback: "",
+			want:     "ssh -F ~/.ssh/config -oBatchMode=yes",
+		},
+		{
+			name:     "falls back to GIT_SSH binary",
+			existing: "",
+			fallback: "/tmp/custom ssh",
+			want:     "'/tmp/custom ssh' -oBatchMode=yes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := nonInteractiveSSHCommand(tt.existing, tt.fallback); got != tt.want {
+				t.Fatalf("nonInteractiveSSHCommand(%q, %q) = %q, want %q", tt.existing, tt.fallback, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildNonInteractiveGitEnv(t *testing.T) {
+	cfg := &config.AppConfig{WorktreeDir: t.TempDir()}
+	m := NewModel(cfg, "")
+
+	t.Setenv("GIT_TERMINAL_PROMPT", "1")
+	t.Setenv("GIT_SSH_COMMAND", "ssh -F ~/.ssh/config")
+
+	env := m.buildNonInteractiveGitEnv("feature", "/tmp/wt")
+
+	values := map[string]string{}
+	for _, entry := range env {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok {
+			values[key] = value
+		}
+	}
+
+	if got := values["GIT_TERMINAL_PROMPT"]; got != "0" {
+		t.Fatalf("expected GIT_TERMINAL_PROMPT=0, got %q", got)
+	}
+	if got := values["GIT_SSH_COMMAND"]; got != "ssh -F ~/.ssh/config -oBatchMode=yes" {
+		t.Fatalf("expected batch mode ssh command, got %q", got)
+	}
+	if got := values["WORKTREE_BRANCH"]; got != "feature" {
+		t.Fatalf("expected WORKTREE_BRANCH to be propagated, got %q", got)
+	}
+}
+
+func TestBuildNonInteractiveGitEnvFallsBackToGitSSH(t *testing.T) {
+	cfg := &config.AppConfig{WorktreeDir: t.TempDir()}
+	m := NewModel(cfg, "")
+
+	t.Setenv("GIT_TERMINAL_PROMPT", "1")
+	t.Setenv("GIT_SSH_COMMAND", "")
+	t.Setenv("GIT_SSH", "/tmp/custom ssh")
+
+	env := m.buildNonInteractiveGitEnv("feature", "/tmp/wt")
+
+	values := map[string]string{}
+	for _, entry := range env {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok {
+			values[key] = value
+		}
+	}
+
+	if got := values["GIT_SSH_COMMAND"]; got != "'/tmp/custom ssh' -oBatchMode=yes" {
+		t.Fatalf("expected fallback GIT_SSH command, got %q", got)
 	}
 }
 

--- a/internal/app/worktree_sync.go
+++ b/internal/app/worktree_sync.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 
@@ -261,11 +260,7 @@ func hasLocalChanges(wt *models.WorktreeInfo) bool {
 
 // runPush executes a git push command.
 func (m *Model) runPush(wt *models.WorktreeInfo, args []string) tea.Cmd {
-	env := m.buildCommandEnv(wt.Branch, wt.Path)
-	envVars := os.Environ()
-	for k, v := range env {
-		envVars = append(envVars, fmt.Sprintf("%s=%s", k, v))
-	}
+	envVars := m.buildNonInteractiveGitEnv(wt.Branch, wt.Path)
 
 	// Clear cache so status pane refreshes with latest git status
 	m.deleteDetailsCache(wt.Path)
@@ -286,11 +281,7 @@ func (m *Model) runPush(wt *models.WorktreeInfo, args []string) tea.Cmd {
 
 // runSync executes a git pull followed by push.
 func (m *Model) runSync(wt *models.WorktreeInfo, pullArgs, pushArgs []string) tea.Cmd {
-	env := m.buildCommandEnv(wt.Branch, wt.Path)
-	envVars := os.Environ()
-	for k, v := range env {
-		envVars = append(envVars, fmt.Sprintf("%s=%s", k, v))
-	}
+	envVars := m.buildNonInteractiveGitEnv(wt.Branch, wt.Path)
 
 	// Clear cache so status pane refreshes with latest git status
 	m.deleteDetailsCache(wt.Path)

--- a/internal/app/worktree_sync_test.go
+++ b/internal/app/worktree_sync_test.go
@@ -72,6 +72,58 @@ func TestPushToUpstreamRunsGitPush(t *testing.T) {
 	}
 }
 
+func TestPushToUpstreamDisablesInteractivePrompts(t *testing.T) {
+	cfg := &config.AppConfig{WorktreeDir: t.TempDir()}
+	m := NewModel(cfg, "")
+
+	wtPath := filepath.Join(cfg.WorktreeDir, "wt1")
+	if err := os.MkdirAll(wtPath, 0o700); err != nil {
+		t.Fatalf("failed to create worktree dir: %v", err)
+	}
+
+	t.Setenv("GIT_TERMINAL_PROMPT", "1")
+	t.Setenv("GIT_SSH_COMMAND", "ssh -F ~/.ssh/config")
+
+	wt := &models.WorktreeInfo{Path: wtPath, Branch: featureBranch}
+
+	var captured *exec.Cmd
+	m.commandRunner = func(_ context.Context, name string, args ...string) *exec.Cmd {
+		if name == "git" && len(args) > 0 && args[0] == "worktree" {
+			return exec.Command("printf", "")
+		}
+		cmd := exec.Command("printf", "")
+		captured = cmd
+		return cmd
+	}
+
+	msg := m.runPush(wt, []string{testRemoteOrigin, "HEAD:" + featureBranch})()
+	pushMsg, ok := msg.(pushResultMsg)
+	if !ok {
+		t.Fatalf("expected pushResultMsg, got %T", msg)
+	}
+	if pushMsg.err != nil {
+		t.Fatalf("unexpected push error: %v", pushMsg.err)
+	}
+	if captured == nil {
+		t.Fatal("expected git command to be captured")
+	}
+
+	env := map[string]string{}
+	for _, entry := range captured.Env {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok {
+			env[key] = value
+		}
+	}
+
+	if got := env["GIT_TERMINAL_PROMPT"]; got != "0" {
+		t.Fatalf("expected GIT_TERMINAL_PROMPT=0, got %q", got)
+	}
+	if got := env["GIT_SSH_COMMAND"]; got != "ssh -F ~/.ssh/config -oBatchMode=yes" {
+		t.Fatalf("expected batch mode ssh command, got %q", got)
+	}
+}
+
 func TestPushToUpstreamPromptsForUpstream(t *testing.T) {
 	cfg := &config.AppConfig{
 		WorktreeDir: t.TempDir(),
@@ -299,6 +351,62 @@ func TestSyncWithUpstreamRunsPullThenPush(t *testing.T) {
 	}
 	if len(calls[1].args) < 3 || calls[1].args[1] != testRemoteOrigin || calls[1].args[2] != "HEAD:"+featureBranch {
 		t.Fatalf("expected git push origin HEAD:%s, got %v", featureBranch, calls[1].args)
+	}
+}
+
+func TestSyncWithUpstreamDisablesInteractivePrompts(t *testing.T) {
+	cfg := &config.AppConfig{
+		WorktreeDir: t.TempDir(),
+		MergeMethod: "merge",
+	}
+	m := NewModel(cfg, "")
+
+	wtPath := filepath.Join(cfg.WorktreeDir, "wt1")
+	if err := os.MkdirAll(wtPath, 0o700); err != nil {
+		t.Fatalf("failed to create worktree dir: %v", err)
+	}
+
+	t.Setenv("GIT_TERMINAL_PROMPT", "1")
+	t.Setenv("GIT_SSH_COMMAND", "ssh -F ~/.ssh/config")
+
+	wt := &models.WorktreeInfo{Path: wtPath, Branch: featureBranch}
+
+	var captured []*exec.Cmd
+	m.commandRunner = func(_ context.Context, name string, args ...string) *exec.Cmd {
+		if name == "git" && len(args) > 0 && args[0] == "worktree" {
+			return exec.Command("printf", "")
+		}
+		cmd := exec.Command("printf", "")
+		captured = append(captured, cmd)
+		return cmd
+	}
+
+	msg := m.runSync(wt, []string{testRemoteOrigin, featureBranch}, []string{testRemoteOrigin, "HEAD:" + featureBranch})()
+	syncMsg, ok := msg.(syncResultMsg)
+	if !ok {
+		t.Fatalf("expected syncResultMsg, got %T", msg)
+	}
+	if syncMsg.err != nil {
+		t.Fatalf("unexpected sync error: %v", syncMsg.err)
+	}
+	if len(captured) != 2 {
+		t.Fatalf("expected 2 git commands, got %d", len(captured))
+	}
+
+	for i, cmd := range captured {
+		env := map[string]string{}
+		for _, entry := range cmd.Env {
+			key, value, ok := strings.Cut(entry, "=")
+			if ok {
+				env[key] = value
+			}
+		}
+		if got := env["GIT_TERMINAL_PROMPT"]; got != "0" {
+			t.Fatalf("command %d expected GIT_TERMINAL_PROMPT=0, got %q", i, got)
+		}
+		if got := env["GIT_SSH_COMMAND"]; got != "ssh -F ~/.ssh/config -oBatchMode=yes" {
+			t.Fatalf("command %d expected batch mode ssh command, got %q", i, got)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- disable interactive git credential prompts for foreground push and sync operations in the TUI
- force SSH-backed git commands into batch mode so they fail fast instead of waiting on terminal input
- add regression coverage for the non-interactive env helper and the push/sync execution path

## Why
Push and sync were using foreground git commands that could block the TUI when git fell back to interactive HTTPS or SSH authentication prompts.

## Impact
Users now see a git error in the TUI instead of having the interface freeze while waiting for credentials.

## Validation
- `go test ./internal/app/...`
- `make build`
- `make sanity` could not complete because of pre-existing repo-wide `goconst` failures outside this change

Closes #53
