### PR TITLE
[codex] fix GitHub Actions warning noise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,13 +40,16 @@ jobs:
           go-version-file: "go.mod"
 
       - uses: alexellis/setup-arkade@v3
-      - uses: alexellis/arkade-get@master
-        with:
-          golangci-lint: latest
+      - name: Install golangci-lint
+        run: |
+          arkade get golangci-lint
+          echo "$HOME/.arkade/bin" >> "$GITHUB_PATH"
       - name: Set up Gofumpt
         uses: luisnquin/setup-gofumpt@v2
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: false
 
       - name: Run docs sync checks
         run: |

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: false
 
       - name: Validate docs synchronisation
         env:


### PR DESCRIPTION
## What changed
This updates the GitHub Actions workflows to stop emitting avoidable warnings during CI and pages runs.

## Why
The CI workflow still used `alexellis/arkade-get@master`, which is flagged for the Node.js 20 runtime deprecation. The workflows also used `astral-sh/setup-uv` with its default cache discovery in a repository that does not carry Python dependency manifests, which produced a persistent cache invalidation warning.

## Impact
CI and Pages runs should stay quieter and more future-proof without changing the project build behaviour.

## Validation
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci.yml .github/workflows/pages.yml`
- pre-commit hooks ran automatically during `git push` and passed for the staged workflow files