### PR TITLE
fix: Update worktree renaming to use directory names

### DIFF
--- a/internal/app/worktree_operations.go
+++ b/internal/app/worktree_operations.go
@@ -521,25 +521,29 @@ func (m *Model) showRenameWorktree() tea.Cmd {
 		return nil
 	}
 
-	prompt := fmt.Sprintf("Enter new name for '%s'", wt.Branch)
-	inputScr := appscreen.NewInputScreen(prompt, "New branch name", wt.Branch, m.theme, m.config.IconsEnabled())
+	currentWorktreeName := filepath.Base(wt.Path)
+	prompt := fmt.Sprintf("Enter new name for '%s'", currentWorktreeName)
+	inputScr := appscreen.NewInputScreen(prompt, "New worktree name", currentWorktreeName, m.theme, m.config.IconsEnabled())
 
 	inputScr.OnSubmit = func(value string, _ bool) tea.Cmd {
-		newBranch := strings.TrimSpace(value)
-		newBranch = sanitizeBranchNameFromTitle(newBranch, "")
-		if newBranch == "" {
+		newWorktreeName := strings.TrimSpace(value)
+		newWorktreeName = sanitizeBranchNameFromTitle(newWorktreeName, "")
+		if newWorktreeName == "" {
 			inputScr.ErrorMsg = "Name cannot be empty."
 			return nil
 		}
-		if newBranch == wt.Branch {
-			inputScr.ErrorMsg = "Name must be different from the current branch."
+		if newWorktreeName == currentWorktreeName {
+			inputScr.ErrorMsg = "Name must be different from the current worktree."
 			return nil
 		}
 
 		parentDir := filepath.Dir(wt.Path)
-		newPath := filepath.Join(parentDir, newBranch)
+		newPath := filepath.Join(parentDir, newWorktreeName)
 		if _, err := os.Stat(newPath); err == nil {
 			inputScr.ErrorMsg = fmt.Sprintf("Destination already exists: %s", newPath)
+			return nil
+		} else if !os.IsNotExist(err) {
+			inputScr.ErrorMsg = fmt.Sprintf("Failed to inspect destination: %v", err)
 			return nil
 		}
 
@@ -548,12 +552,12 @@ func (m *Model) showRenameWorktree() tea.Cmd {
 		oldBranch := wt.Branch
 
 		return func() tea.Msg {
-			ok := m.state.services.git.RenameWorktree(m.ctx, oldPath, newPath, oldBranch, newBranch)
+			ok := m.state.services.git.RenameWorktree(m.ctx, oldPath, newPath, oldBranch, newWorktreeName)
 			if !ok {
 				return renameWorktreeResultMsg{
 					oldPath: oldPath,
 					newPath: newPath,
-					err:     fmt.Errorf("failed to rename %s to %s", oldBranch, newBranch),
+					err:     fmt.Errorf("failed to rename worktree %s to %s", currentWorktreeName, newWorktreeName),
 				}
 			}
 			worktrees, err := m.state.services.git.GetWorktrees(m.ctx)

--- a/internal/app/worktree_operations_test.go
+++ b/internal/app/worktree_operations_test.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,6 +13,183 @@ import (
 	"github.com/chmouel/lazyworktree/internal/config"
 	"github.com/chmouel/lazyworktree/internal/models"
 )
+
+func TestShowRenameWorktreeRenamesBranchWhenWorktreeNameMatches(t *testing.T) {
+	cfg := &config.AppConfig{WorktreeDir: t.TempDir()}
+	m := NewModel(cfg, "")
+
+	oldPath := filepath.Join(cfg.WorktreeDir, "repo", "feature")
+	newPath := filepath.Join(cfg.WorktreeDir, "repo", "renamed-worktree")
+	porcelain := fmt.Sprintf("worktree %s\nHEAD abc123\nbranch refs/heads/renamed-worktree\n\n", newPath)
+	var commands [][]string
+
+	m.commandRunner = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		command := append([]string{name}, args...)
+		commands = append(commands, command)
+
+		switch strings.Join(command, " ") {
+		case fmt.Sprintf("git worktree move %s %s", oldPath, newPath):
+			if err := os.MkdirAll(newPath, 0o750); err != nil {
+				t.Fatalf("failed to create moved worktree fixture: %v", err)
+			}
+			return exec.CommandContext(ctx, "sh", "-c", "exit 0")
+		case "git branch -m feature renamed-worktree":
+			return exec.CommandContext(ctx, "sh", "-c", "exit 0")
+		case "git worktree list --porcelain":
+			// #nosec G204 -- test uses controlled fixture output for the command runner.
+			return exec.CommandContext(ctx, "printf", "%s", porcelain)
+		default:
+			return exec.CommandContext(ctx, "sh", "-c", "exit 1")
+		}
+	}
+
+	m.state.data.filteredWts = []*models.WorktreeInfo{
+		{Path: oldPath, Branch: "feature"},
+	}
+	m.state.data.selectedIndex = 0
+
+	cmd := m.showRenameWorktree()
+	if cmd == nil {
+		t.Fatal("expected input command")
+	}
+	if !m.state.ui.screenManager.IsActive() || m.state.ui.screenManager.Type() != appscreen.TypeInput {
+		t.Fatalf("expected input screen, got active=%v type=%v", m.state.ui.screenManager.IsActive(), m.state.ui.screenManager.Type())
+	}
+
+	inputScr := m.state.ui.screenManager.Current().(*appscreen.InputScreen)
+	if inputScr.Prompt != "Enter new name for 'feature'" {
+		t.Fatalf("unexpected prompt: %q", inputScr.Prompt)
+	}
+	if inputScr.Placeholder != "New worktree name" {
+		t.Fatalf("unexpected placeholder: %q", inputScr.Placeholder)
+	}
+	if inputScr.Input.Value() != "feature" {
+		t.Fatalf("unexpected default input: %q", inputScr.Input.Value())
+	}
+
+	renameCmd := inputScr.OnSubmit("renamed-worktree", false)
+	if renameCmd == nil {
+		t.Fatal("expected rename command")
+	}
+
+	msg := renameCmd()
+	result, ok := msg.(renameWorktreeResultMsg)
+	if !ok {
+		t.Fatalf("expected renameWorktreeResultMsg, got %T", msg)
+	}
+	if result.err != nil {
+		t.Fatalf("unexpected rename error: %v", result.err)
+	}
+
+	sawMove := false
+	sawList := false
+	sawBranchRename := false
+	for _, command := range commands {
+		joined := strings.Join(command, " ")
+		if joined == fmt.Sprintf("git worktree move %s %s", oldPath, newPath) {
+			sawMove = true
+		}
+		if joined == "git worktree list --porcelain" {
+			sawList = true
+		}
+		if joined == "git branch -m feature renamed-worktree" {
+			sawBranchRename = true
+		}
+	}
+	if !sawMove {
+		t.Fatalf("expected worktree move command, got %v", commands)
+	}
+	if !sawList {
+		t.Fatalf("expected worktree refresh command, got %v", commands)
+	}
+	if !sawBranchRename {
+		t.Fatalf("expected branch rename command, got %v", commands)
+	}
+}
+
+func TestShowRenameWorktreeMovesDirectoryWithoutRenamingBranchWhenNamesDiffer(t *testing.T) {
+	cfg := &config.AppConfig{WorktreeDir: t.TempDir()}
+	m := NewModel(cfg, "")
+
+	oldPath := filepath.Join(cfg.WorktreeDir, "repo", "feature-custom")
+	newPath := filepath.Join(cfg.WorktreeDir, "repo", "renamed-worktree")
+	porcelain := fmt.Sprintf("worktree %s\nHEAD abc123\nbranch refs/heads/feature\n\n", newPath)
+	var commands [][]string
+
+	m.commandRunner = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		command := append([]string{name}, args...)
+		commands = append(commands, command)
+
+		switch strings.Join(command, " ") {
+		case fmt.Sprintf("git worktree move %s %s", oldPath, newPath):
+			return exec.CommandContext(ctx, "sh", "-c", "exit 0")
+		case "git worktree list --porcelain":
+			// #nosec G204 -- test uses controlled fixture output for the command runner.
+			return exec.CommandContext(ctx, "printf", "%s", porcelain)
+		default:
+			return exec.CommandContext(ctx, "sh", "-c", "exit 1")
+		}
+	}
+
+	m.state.data.filteredWts = []*models.WorktreeInfo{
+		{Path: oldPath, Branch: "feature"},
+	}
+	m.state.data.selectedIndex = 0
+
+	cmd := m.showRenameWorktree()
+	if cmd == nil {
+		t.Fatal("expected input command")
+	}
+	if !m.state.ui.screenManager.IsActive() || m.state.ui.screenManager.Type() != appscreen.TypeInput {
+		t.Fatalf("expected input screen, got active=%v type=%v", m.state.ui.screenManager.IsActive(), m.state.ui.screenManager.Type())
+	}
+
+	inputScr := m.state.ui.screenManager.Current().(*appscreen.InputScreen)
+	if inputScr.Prompt != "Enter new name for 'feature-custom'" {
+		t.Fatalf("unexpected prompt: %q", inputScr.Prompt)
+	}
+	if inputScr.Placeholder != "New worktree name" {
+		t.Fatalf("unexpected placeholder: %q", inputScr.Placeholder)
+	}
+	if inputScr.Input.Value() != "feature-custom" {
+		t.Fatalf("unexpected default input: %q", inputScr.Input.Value())
+	}
+
+	renameCmd := inputScr.OnSubmit("renamed-worktree", false)
+	if renameCmd == nil {
+		t.Fatal("expected rename command")
+	}
+
+	msg := renameCmd()
+	result, ok := msg.(renameWorktreeResultMsg)
+	if !ok {
+		t.Fatalf("expected renameWorktreeResultMsg, got %T", msg)
+	}
+	if result.err != nil {
+		t.Fatalf("unexpected rename error: %v", result.err)
+	}
+
+	sawMove := false
+	sawList := false
+	for _, command := range commands {
+		joined := strings.Join(command, " ")
+		if joined == fmt.Sprintf("git worktree move %s %s", oldPath, newPath) {
+			sawMove = true
+		}
+		if joined == "git worktree list --porcelain" {
+			sawList = true
+		}
+		if len(command) >= 3 && command[0] == "git" && command[1] == "branch" && command[2] == "-m" {
+			t.Fatalf("unexpected branch rename command: %v", command)
+		}
+	}
+	if !sawMove {
+		t.Fatalf("expected worktree move command, got %v", commands)
+	}
+	if !sawList {
+		t.Fatalf("expected worktree refresh command, got %v", commands)
+	}
+}
 
 func TestShowCreateWorktreeFromChangesNoSelection(t *testing.T) {
 	cfg := &config.AppConfig{

--- a/internal/git/service_worktree.go
+++ b/internal/git/service_worktree.go
@@ -212,10 +212,15 @@ func (s *Service) GetMainWorktreePath(ctx context.Context) string {
 	return s.mainWorktreePath
 }
 
+// MoveWorktree renames a worktree directory without changing its branch.
+func (s *Service) MoveWorktree(ctx context.Context, oldPath, newPath string) bool {
+	return s.RunCommandChecked(ctx, []string{"git", "worktree", "move", oldPath, newPath}, "", fmt.Sprintf("Failed to move worktree from %s to %s", oldPath, newPath))
+}
+
 // RenameWorktree moves a worktree and renames its branch only when the
 // worktree directory name matches the old branch name.
 func (s *Service) RenameWorktree(ctx context.Context, oldPath, newPath, oldBranch, newBranch string) bool {
-	if !s.RunCommandChecked(ctx, []string{"git", "worktree", "move", oldPath, newPath}, "", fmt.Sprintf("Failed to move worktree from %s to %s", oldPath, newPath)) {
+	if !s.MoveWorktree(ctx, oldPath, newPath) {
 		return false
 	}
 

--- a/internal/git/service_worktree_test.go
+++ b/internal/git/service_worktree_test.go
@@ -105,6 +105,30 @@ func TestRenameWorktree(t *testing.T) {
 	})
 }
 
+func TestMoveWorktree(t *testing.T) {
+	t.Parallel()
+	notify := func(_ string, _ string) {}
+	notifyOnce := func(_ string, _ string, _ string) {}
+
+	service := NewService(notify, notifyOnce)
+	ctx := context.Background()
+
+	tmpDir := t.TempDir()
+	oldPath := filepath.Join(tmpDir, "feature")
+	newPath := filepath.Join(tmpDir, "renamed-feature")
+
+	var commands [][]string
+	service.SetCommandRunner(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		commands = append(commands, append([]string{name}, args...))
+		return exec.CommandContext(ctx, "sh", "-c", "exit 0")
+	})
+
+	ok := service.MoveWorktree(ctx, oldPath, newPath)
+	require.True(t, ok)
+	require.Len(t, commands, 1)
+	assert.Equal(t, []string{"git", "worktree", "move", oldPath, newPath}, commands[0])
+}
+
 func TestWorktreeOperations(t *testing.T) {
 	t.Parallel()
 	notify := func(_ string, _ string) {}


### PR DESCRIPTION
Changed the rename logic to target the worktree directory name instead
of the branch name. Updated UI prompts and error messages to use
worktree terminology. Added a check for filesystem errors when
inspecting destination paths before moving. Introduced a dedicated
method for moving worktree directories in the Git service and added
tests to verify behavior when worktree and branch names differ.

Signed-off-by: Chmouel Boudjnah <chmouel@chmouel.com>
