### PR TITLE
[codex] feat(cli): add machine-readable commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ _[You can see more screenshots here](https://chmouel.github.io/lazyworktree/#scr
 - Hooks - `.wt` files per worktree to automate setup and cleanup tasks
 - Customise worktree metadata - Press `e` in the worktree pane to edit the description, colour, notes, icon, and tags for the selected worktree.
 - Shell helpers - `cd "$(lazyworktree)"` shortcut and shell completion for bash, zsh, and fish (making it easy to jump to worktrees from the terminal)
+- LLM-friendly CLI - Use `doctor`, `describe`, `worktrees ...`, and `notes get` for stable JSON automation without launching the TUI
 
 ## Documentation
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,10 +1,20 @@
 # CLI Usage
 
-The CLI supports listing, creating, deleting, renaming, and executing commands in worktrees without launching the full TUI.
+The CLI supports both human-first worktree lifecycle commands and machine-first read commands without launching the full TUI.
 
 <div class="lw-callout">
   <p><strong>Quick command cookbook:</strong> <code>lazyworktree list</code>, <code>lazyworktree create ...</code>, <code>lazyworktree delete ...</code>, and <code>lazyworktree exec ...</code>.</p>
 </div>
+
+For coding agents and scripts, start with:
+
+```bash
+lazyworktree describe
+lazyworktree doctor --json
+lazyworktree worktrees list --json
+lazyworktree worktrees resolve --name my-feature --json
+lazyworktree notes get my-feature --json
+```
 
 ## Config Overrides
 
@@ -25,6 +35,25 @@ lazyworktree ls                # Alias
 ```
 
 `--pristine` and `--json` are mutually exclusive.
+
+## Machine-readable discovery
+
+```bash
+lazyworktree doctor --json
+lazyworktree worktrees list --json
+lazyworktree worktrees resolve --name my-feature --json
+lazyworktree worktrees get my-feature --json
+lazyworktree worktrees context my-feature --json
+lazyworktree notes get my-feature --json
+```
+
+These commands are designed for automation:
+
+- `doctor` reports repository and tool health without failing when setup is incomplete
+- `worktrees resolve` turns a name, branch, or path into a canonical worktree path
+- `worktrees get` reads one exact worktree
+- `worktrees context` returns note and agent-session context for one worktree
+- `notes get` returns note metadata in a stable JSON shape
 
 ## Creating Worktrees
 

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -1,6 +1,6 @@
 # CLI Commands Reference
 
-This page is generated from `internal/bootstrap/commands.go`. Run `make docs-sync` after changing command definitions.
+This page is generated from `internal/bootstrap/*.go`. Run `make docs-sync` after changing command definitions.
 
 <!-- BEGIN GENERATED:cli-commands -->
 | Command | Usage | Args | Aliases | Guide |
@@ -9,8 +9,12 @@ This page is generated from `internal/bootstrap/commands.go`. Run `make docs-syn
 | `create` | Create a new worktree | `[worktree-name]` | - | [`create`](create.md) |
 | `delete` | Delete a worktree | `[worktree-path]` | - | [`delete`](delete.md) |
 | `rename` | Rename a worktree | `<new-name> \| <worktree> <new-name>` | - | [`rename`](rename.md) |
+| `doctor` | Report CLI, repository, and tooling health for automation | `-` | - | [`doctor`](doctor.md) |
+| `worktrees` | Discover and inspect worktrees with stable machine-readable output | `-` | - | [`worktrees`](worktrees.md) |
+| `notes` | Read worktree notes with machine-readable output | `-` | - | [`notes`](notes.md) |
 | `exec` | Run a command or trigger a key action in a worktree | `[command]` | - | [`exec`](exec.md) |
 | `note` | Show or edit worktree notes | `-` | - | [`note`](note.md) |
+| `describe` | Describe the CLI structure as JSON for machine-readable introspection | `[command] [subcommand]` | - | [`describe`](describe.md) |
 
 ## `list`
 
@@ -67,6 +71,28 @@ Rename a worktree
 | `--json` | `bool` | Output result as JSON |
 | `--silent` | `bool` | Suppress progress messages |
 
+## `doctor`
+
+Report CLI, repository, and tooling health for automation
+
+| Flag | Type | Usage |
+| --- | --- | --- |
+| `--json` | `bool` | Output result as JSON |
+
+## `worktrees`
+
+Discover and inspect worktrees with stable machine-readable output
+
+No command-specific flags.
+
+## `notes`
+
+Read worktree notes with machine-readable output
+
+| Flag | Type | Usage |
+| --- | --- | --- |
+| `--json` | `bool` | (get) Output result as JSON including metadata |
+
 ## `exec`
 
 Run a command or trigger a key action in a worktree
@@ -85,5 +111,13 @@ Show or edit worktree notes
 | --- | --- | --- |
 | `--input`, `-i` | `string` | (edit) Read note from file (use '-' for stdin) |
 | `--json` | `bool` | (show) Output note as JSON including metadata |
+
+## `describe`
+
+Describe the CLI structure as JSON for machine-readable introspection
+
+| Flag | Type | Usage |
+| --- | --- | --- |
+| `--all` | `bool` | Describe all commands and their flags |
 
 <!-- END GENERATED:cli-commands -->

--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -1,0 +1,34 @@
+# doctor
+
+Report CLI, repository, and tooling health for automation.
+
+## Synopsis
+
+```bash
+lazyworktree doctor
+lazyworktree doctor --json
+```
+
+## Why use it first
+
+`doctor` is the safest entry point for coding agents and scripts. It confirms:
+
+- whether a repository is visible from the current directory
+- whether worktrees can be listed
+- whether a config file was loaded
+- whether helper tools such as `git`, `gh`, and `glab` are available
+
+Unlike most operational commands, `doctor --json` remains useful even when setup is incomplete.
+
+## Examples
+
+```bash
+lazyworktree doctor --json
+lazyworktree doctor --json | jq '{repo: .repository.repo, worktree_count: .repository.worktree_count}'
+```
+
+## Output notes
+
+- Human output is brief and diagnostic.
+- `--json` writes structured output to stdout only.
+- Setup gaps are reported in the JSON payload instead of causing a hard failure.

--- a/docs/cli/flags.md
+++ b/docs/cli/flags.md
@@ -1,6 +1,6 @@
 # CLI Flags Reference
 
-This page is generated from `internal/bootstrap/flags.go` and `internal/bootstrap/commands.go`.
+This page is generated from `internal/bootstrap/flags.go` and `internal/bootstrap/*.go`.
 Run `make docs-sync` after changing flag definitions.
 
 ## Global Flags
@@ -68,6 +68,18 @@ Run `make docs-sync` after changing flag definitions.
 | `--json` | `bool` | Output result as JSON |
 | `--silent` | `bool` | Suppress progress messages |
 
+### `doctor`
+
+| Flag | Type | Usage |
+| --- | --- | --- |
+| `--json` | `bool` | Output result as JSON |
+
+### `notes`
+
+| Flag | Type | Usage |
+| --- | --- | --- |
+| `--json` | `bool` | (get) Output result as JSON including metadata |
+
 ### `exec`
 
 | Flag | Type | Usage |
@@ -83,11 +95,17 @@ Run `make docs-sync` after changing flag definitions.
 | `--input`, `-i` | `string` | (edit) Read note from file (use '-' for stdin) |
 | `--json` | `bool` | (show) Output note as JSON including metadata |
 
+### `describe`
+
+| Flag | Type | Usage |
+| --- | --- | --- |
+| `--all` | `bool` | Describe all commands and their flags |
+
 <!-- END GENERATED:command-flags -->
 
 ## Validation Rules
 
-These runtime rules are enforced in `internal/bootstrap/commands.go`:
+These runtime rules are enforced in `internal/bootstrap/*.go`:
 
 - `create`: `--from-pr`, `--from-issue`, `--from-pr-interactive`, and `--from-issue-interactive` are mutually exclusive.
 - `create`: `--query` requires `--from-pr-interactive` or `--from-issue-interactive`.

--- a/docs/cli/notes.md
+++ b/docs/cli/notes.md
@@ -1,0 +1,23 @@
+# notes
+
+Read worktree notes with machine-readable output.
+
+## Subcommands
+
+### `notes get <worktree>`
+
+Return note metadata for one exact worktree.
+
+| Flag | Type | Usage |
+| --- | --- | --- |
+| `--json` | `bool` | Output result as JSON including metadata |
+
+Use this command when you want a stable JSON note payload. The older `note show` command remains available for plain-text note output and editor-driven note changes.
+
+## Examples
+
+```bash
+lazyworktree notes get my-feature --json
+lazyworktree worktrees resolve --name my-feature --json | jq -r '.worktree.path'
+lazyworktree notes get /path/to/worktree --json
+```

--- a/docs/cli/overview.md
+++ b/docs/cli/overview.md
@@ -1,6 +1,6 @@
 # CLI Overview
 
-Use the CLI to manage worktrees non-interactively or in scripts.
+Use the CLI to manage worktrees non-interactively, in scripts, and from coding agents.
 
 ## Available Commands
 
@@ -8,7 +8,11 @@ Use the CLI to manage worktrees non-interactively or in scripts.
 - `lazyworktree create`
 - `lazyworktree delete`
 - `lazyworktree rename`
+- `lazyworktree doctor`
+- `lazyworktree worktrees ...`
+- `lazyworktree notes get`
 - `lazyworktree exec`
+- `lazyworktree describe`
 
 Global config overrides:
 
@@ -19,6 +23,9 @@ lazyworktree --config lw.theme=nord --config lw.sort_mode=active
 
 ## Command Pages
 
+- [`doctor`](doctor.md)
+- [`worktrees`](worktrees.md)
+- [`notes`](notes.md)
 - [`list`](list.md)
 - [`create`](create.md)
 - [`delete`](delete.md)
@@ -33,3 +40,15 @@ For complete generated references, use:
 - [CLI Flags Reference](flags.md)
 - `lazyworktree --help`
 - `man lazyworktree`
+
+## Machine-first workflow
+
+For Codex or script automation, prefer this order:
+
+1. `lazyworktree describe`
+2. `lazyworktree doctor --json`
+3. `lazyworktree worktrees list --json`
+4. `lazyworktree worktrees resolve --name <name> --json`
+5. `lazyworktree worktrees get <path-or-name> --json`
+6. `lazyworktree worktrees context <path-or-name> --json`
+7. `lazyworktree notes get <path-or-name> --json`

--- a/docs/cli/worktrees.md
+++ b/docs/cli/worktrees.md
@@ -1,0 +1,68 @@
+# worktrees
+
+Discover, resolve, and inspect worktrees with stable machine-readable output.
+
+## Subcommands
+
+### `worktrees list`
+
+List worktrees for the current repository.
+
+Useful flags:
+
+| Flag | Type | Usage |
+| --- | --- | --- |
+| `--json` | `bool` | Output result as JSON |
+| `--main` | `bool` | Show only the main worktree |
+| `--limit` | `int` | Limit the number of returned worktrees |
+| `--no-agent` | `bool` | Skip agent session data |
+
+### `worktrees resolve`
+
+Resolve a worktree name, branch, path, or cwd into a canonical worktree path.
+
+Useful flags:
+
+| Flag | Type | Usage |
+| --- | --- | --- |
+| `--json` | `bool` | Output result as JSON |
+| `--name` | `string` | Resolve by name, basename, or branch |
+| `--path` | `string` | Resolve by path or a path inside the worktree |
+| `--cwd` | `string` | Resolve by working directory |
+| `--no-agent` | `bool` | Skip agent session data |
+
+### `worktrees get <worktree>`
+
+Read one exact worktree by canonical path, name, or branch.
+
+### `worktrees context <worktree>`
+
+Read note and agent-session context for one worktree.
+
+Useful flags:
+
+| Flag | Type | Usage |
+| --- | --- | --- |
+| `--json` | `bool` | Output result as JSON |
+| `--include` | `string` | Comma-separated sections: `notes`, `agents` |
+
+## Examples
+
+```bash
+lazyworktree worktrees list --json
+lazyworktree worktrees list --main --json
+lazyworktree worktrees resolve --name my-feature --json
+lazyworktree worktrees resolve --path ~/worktrees/repo/my-feature --json
+lazyworktree worktrees get my-feature --json
+lazyworktree worktrees context my-feature --json
+lazyworktree worktrees context my-feature --include notes --json
+```
+
+## Agent workflow
+
+For coding agents, the usual order is:
+
+1. `lazyworktree worktrees list --json`
+2. `lazyworktree worktrees resolve --name <name> --json`
+3. `lazyworktree worktrees get <path-or-name> --json`
+4. `lazyworktree worktrees context <path-or-name> --json`

--- a/docs/guides/ai-integration.md
+++ b/docs/guides/ai-integration.md
@@ -23,7 +23,31 @@ lazyworktree describe note show | jq '.'
 
 `describe` always emits valid JSON and exits 0 on success. The output is stable and safe to parse programmatically.
 
-### 2. Use `--json` for machine-readable output
+### 2. Verify setup with `doctor`
+
+Use `doctor --json` before assuming repository state or helper tools are available:
+
+```bash
+lazyworktree doctor --json | jq '{repo: .repository.repo, worktrees: .repository.worktree_count, git: .tools.git.available}'
+```
+
+`doctor --json` reports config loading, repository detection, worktree visibility, and helper tool availability. It remains usable even when the current directory is not ready for full worktree operations.
+
+### 3. Resolve and read exact worktrees
+
+Prefer resolving once, then reading exact objects:
+
+```bash
+lazyworktree worktrees list --json | jq '.items[].name'
+lazyworktree worktrees resolve --name my-feature --json | jq -r '.worktree.path'
+lazyworktree worktrees get my-feature --json | jq '{path, branch, dirty}'
+lazyworktree worktrees context my-feature --json | jq '{worktree, note}'
+lazyworktree notes get my-feature --json | jq '{note, description, tags}'
+```
+
+These commands keep discovery, resolution, and exact reads separate so follow-up commands do not have to repeat broad searches.
+
+### 4. Use `--json` for existing lifecycle commands
 
 Every mutating command (`create`, `delete`, `rename`) and `note show` accept `--json`. In this mode:
 
@@ -45,7 +69,7 @@ lazyworktree list --json | jq '.[].agent_count'
 lazyworktree note show --json | jq '{note, description, tags}'
 ```
 
-### 3. Use `exec --json` for command automation
+### 5. Use `exec --json` for command automation
 
 ```bash
 # Run a command in a worktree and capture the exit code
@@ -58,6 +82,9 @@ echo "$result" | jq '.exit_code'
 | Method | When to use |
 |---|---|
 | `describe` | Discover available flags and subcommands |
+| `doctor --json` | Verify config, repo visibility, and helper tools |
+| `worktrees ... --json` | Discover, resolve, and read exact worktree state |
+| `notes get --json` | Read exact note metadata for one worktree |
 | `--json` flags | Parse command results programmatically |
 | `--help` | Human-readable reference only — do not parse |
 

--- a/hack/docsync/main.go
+++ b/hack/docsync/main.go
@@ -15,7 +15,6 @@ import (
 	pathpkg "path"
 	"path/filepath"
 	"regexp"
-	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -109,7 +108,7 @@ func main() {
 
 func collectDocsSyncData(root string) (*docsSyncData, error) {
 	flagsPath := filepath.Join(root, "internal", "bootstrap", "flags.go")
-	commandsPath := filepath.Join(root, "internal", "bootstrap", "commands.go")
+	commandsDir := filepath.Join(root, "internal", "bootstrap")
 	configPath := filepath.Join(root, "internal", "config", "config.go")
 	registryPath := filepath.Join(root, "internal", "app", "commands", "registry.go")
 
@@ -118,7 +117,7 @@ func collectDocsSyncData(root string) (*docsSyncData, error) {
 		return nil, err
 	}
 
-	commands, err := parseCommands(commandsPath)
+	commands, err := parseCommands(commandsDir)
 	if err != nil {
 		return nil, err
 	}
@@ -203,41 +202,69 @@ func parseGlobalFlags(path string) ([]flagSpec, error) {
 	return nil, errors.New("globalFlags function not found")
 }
 
-func parseCommands(path string) ([]commandSpec, error) {
+func parseCommands(dir string) ([]commandSpec, error) {
 	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return nil, fmt.Errorf("parse commands file: %w", err)
+		return nil, fmt.Errorf("read commands directory: %w", err)
+	}
+
+	files := make([]*ast.File, 0, len(entries))
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || strings.HasSuffix(name, "_test.go") || !strings.HasSuffix(name, ".go") {
+			continue
+		}
+
+		path := filepath.Join(dir, name)
+		file, parseErr := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if parseErr != nil {
+			return nil, fmt.Errorf("parse commands file %s: %w", path, parseErr)
+		}
+		if file.Name == nil || file.Name.Name != "bootstrap" {
+			continue
+		}
+		files = append(files, file)
+	}
+	if len(files) == 0 {
+		return nil, errors.New("bootstrap command files not found")
 	}
 
 	var commands []commandSpec
-	for _, decl := range file.Decls {
-		fn, ok := decl.(*ast.FuncDecl)
-		if !ok {
-			continue
-		}
-		if !strings.HasSuffix(fn.Name.Name, "Command") {
-			continue
-		}
+	allowedFuncs := map[string]struct{}{
+		"createCommand": {}, "deleteCommand": {}, "renameCommand": {}, "listCommand": {},
+		"execCommand": {}, "noteCommand": {}, "describeCommand": {}, "doctorCommand": {},
+		"worktreesCommand": {}, "notesCommand": {},
+	}
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok {
+				continue
+			}
+			if _, ok := allowedFuncs[fn.Name.Name]; !ok {
+				continue
+			}
 
-		lit := extractReturnedCompositeLit(fn)
-		if lit == nil {
-			continue
-		}
+			lit := extractReturnedCompositeLit(fn)
+			if lit == nil {
+				continue
+			}
 
-		cmd := parseCommandLiteral(lit)
-		if cmd.Name == "" {
-			continue
+			cmd := parseCommandLiteral(lit)
+			if cmd.Name == "" {
+				continue
+			}
+			sort.Slice(cmd.Flags, func(i, j int) bool { return cmd.Flags[i].Name < cmd.Flags[j].Name })
+			commands = append(commands, cmd)
 		}
-		if !slices.Contains([]string{"create", "delete", "rename", "list", "exec", "note"}, cmd.Name) {
-			continue
-		}
-		sort.Slice(cmd.Flags, func(i, j int) bool { return cmd.Flags[i].Name < cmd.Flags[j].Name })
-		commands = append(commands, cmd)
 	}
 
 	// Parse note subcommands (show, edit) and attach their flags to the parent.
-	noteCmd := parseNoteSubcommands(file, commands)
+	noteCmd := parseMergedParentCommand(files, "note", map[string]string{
+		"noteShowCommand": "show",
+		"noteEditCommand": "edit",
+	}, "Show or edit worktree notes")
 	if noteCmd != nil {
 		for i, cmd := range commands {
 			if cmd.Name == "note" {
@@ -247,49 +274,62 @@ func parseCommands(path string) ([]commandSpec, error) {
 		}
 	}
 
+	notesCmd := parseMergedParentCommand(files, "notes", map[string]string{
+		"notesGetCommand": "get",
+	}, "Read worktree notes with machine-readable output")
+	if notesCmd != nil {
+		for i, cmd := range commands {
+			if cmd.Name == "notes" {
+				commands[i] = *notesCmd
+				break
+			}
+		}
+	}
+
 	if len(commands) == 0 {
 		return nil, errors.New("no command definitions found")
 	}
 
-	order := map[string]int{"list": 0, "create": 1, "delete": 2, "rename": 3, "exec": 4, "note": 5}
+	order := map[string]int{
+		"list": 0, "create": 1, "delete": 2, "rename": 3, "doctor": 4,
+		"worktrees": 5, "notes": 6, "exec": 7, "note": 8, "describe": 9,
+	}
 	sort.Slice(commands, func(i, j int) bool {
 		return order[commands[i].Name] < order[commands[j].Name]
 	})
 	return commands, nil
 }
 
-// parseNoteSubcommands extracts the show and edit subcommand definitions and
-// merges their flags into a single "note" commandSpec for documentation.
-func parseNoteSubcommands(file *ast.File, _ []commandSpec) *commandSpec {
-	subFuncs := map[string]string{
-		"noteShowCommand": "show",
-		"noteEditCommand": "edit",
-	}
+// parseMergedParentCommand extracts the given subcommand definitions and merges
+// their flags into a single parent commandSpec for documentation.
+func parseMergedParentCommand(files []*ast.File, parentName string, subFuncs map[string]string, usage string) *commandSpec {
 	var subs []commandSpec
-	for _, decl := range file.Decls {
-		fn, ok := decl.(*ast.FuncDecl)
-		if !ok {
-			continue
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok {
+				continue
+			}
+			subName, ok := subFuncs[fn.Name.Name]
+			if !ok {
+				continue
+			}
+			lit := extractReturnedCompositeLit(fn)
+			if lit == nil {
+				continue
+			}
+			sub := parseCommandLiteral(lit)
+			sub.Name = subName
+			subs = append(subs, sub)
 		}
-		subName, ok := subFuncs[fn.Name.Name]
-		if !ok {
-			continue
-		}
-		lit := extractReturnedCompositeLit(fn)
-		if lit == nil {
-			continue
-		}
-		sub := parseCommandLiteral(lit)
-		sub.Name = subName
-		subs = append(subs, sub)
 	}
 	if len(subs) == 0 {
 		return nil
 	}
 
 	cmd := &commandSpec{
-		Name:  "note",
-		Usage: "Show or edit worktree notes",
+		Name:  parentName,
+		Usage: usage,
 	}
 	// Merge subcommand flags with subcommand prefix for documentation clarity.
 	for _, sub := range subs {
@@ -846,7 +886,7 @@ func orderedConfigKeys(keys []string) []string {
 func renderCLICommandsPage(commands []commandSpec) string {
 	var b strings.Builder
 	b.WriteString("# CLI Commands Reference\n\n")
-	b.WriteString("This page is generated from `internal/bootstrap/commands.go`. Run `make docs-sync` after changing command definitions.\n\n")
+	b.WriteString("This page is generated from `internal/bootstrap/*.go`. Run `make docs-sync` after changing command definitions.\n\n")
 	b.WriteString("<!-- BEGIN GENERATED:cli-commands -->\n")
 	b.WriteString("| Command | Usage | Args | Aliases | Guide |\n")
 	b.WriteString("| --- | --- | --- | --- | --- |\n")
@@ -884,7 +924,7 @@ func renderCLICommandsPage(commands []commandSpec) string {
 func renderCLIFlagsPage(global []flagSpec, commands []commandSpec) string {
 	var b strings.Builder
 	b.WriteString("# CLI Flags Reference\n\n")
-	b.WriteString("This page is generated from `internal/bootstrap/flags.go` and `internal/bootstrap/commands.go`.\n")
+	b.WriteString("This page is generated from `internal/bootstrap/flags.go` and `internal/bootstrap/*.go`.\n")
 	b.WriteString("Run `make docs-sync` after changing flag definitions.\n\n")
 
 	b.WriteString("## Global Flags\n\n")
@@ -913,7 +953,7 @@ func renderCLIFlagsPage(global []flagSpec, commands []commandSpec) string {
 	b.WriteString("<!-- END GENERATED:command-flags -->\n\n")
 
 	b.WriteString("## Validation Rules\n\n")
-	b.WriteString("These runtime rules are enforced in `internal/bootstrap/commands.go`:\n\n")
+	b.WriteString("These runtime rules are enforced in `internal/bootstrap/*.go`:\n\n")
 	b.WriteString("- `create`: `--from-pr`, `--from-issue`, `--from-pr-interactive`, and `--from-issue-interactive` are mutually exclusive.\n")
 	b.WriteString("- `create`: `--query` requires `--from-pr-interactive` or `--from-issue-interactive`.\n")
 	b.WriteString("- `create`: `--no-workspace` requires PR/issue creation mode and cannot be combined with `--with-change` or `--generate`.\n")

--- a/hack/docsync/main_test.go
+++ b/hack/docsync/main_test.go
@@ -23,13 +23,13 @@ func TestParseGlobalFlags(t *testing.T) {
 }
 
 func TestParseCommands(t *testing.T) {
-	path := filepath.Join("..", "..", "internal", "bootstrap", "commands.go")
+	path := filepath.Join("..", "..", "internal", "bootstrap")
 	commands, err := parseCommands(path)
 	if err != nil {
 		t.Fatalf("parseCommands returned error: %v", err)
 	}
 
-	required := []string{"list", "create", "delete", "rename", "exec"}
+	required := []string{"list", "create", "delete", "rename", "doctor", "worktrees", "notes", "exec", "describe"}
 	for _, name := range required {
 		if !containsCommand(commands, name) {
 			t.Fatalf("expected command %q", name)

--- a/internal/app/app_helpers.go
+++ b/internal/app/app_helpers.go
@@ -141,7 +141,8 @@ func (m *Model) buildNonInteractiveGitEnv(branch, wtPath string) []string {
 	envVars := filterWorktreeEnvVars(os.Environ())
 	envVars = filterEnvVars(envVars, "GIT_TERMINAL_PROMPT", "GIT_SSH_COMMAND")
 	envVars = append(envVars, envMapToList(m.buildCommandEnv(branch, wtPath))...)
-	envVars = append(envVars,
+	envVars = append(
+		envVars,
 		"GIT_TERMINAL_PROMPT=0",
 		fmt.Sprintf("GIT_SSH_COMMAND=%s", nonInteractiveSSHCommand(os.Getenv("GIT_SSH_COMMAND"), os.Getenv("GIT_SSH"))),
 	)

--- a/internal/app/helpers.go
+++ b/internal/app/helpers.go
@@ -33,7 +33,8 @@ func runBranchNameScript(ctx context.Context, script, content, scriptType, numbe
 	cmd.Stdin = strings.NewReader(content)
 
 	// Set environment variables to provide context to the script
-	cmd.Env = append(os.Environ(),
+	cmd.Env = append(
+		os.Environ(),
 		fmt.Sprintf("LAZYWORKTREE_TYPE=%s", scriptType),
 		fmt.Sprintf("LAZYWORKTREE_NUMBER=%s", number),
 		fmt.Sprintf("LAZYWORKTREE_TEMPLATE=%s", template),

--- a/internal/app/pr_worktree_test.go
+++ b/internal/app/pr_worktree_test.go
@@ -306,12 +306,15 @@ func TestHandleWorktreesLoadedAssignsPendingPR(t *testing.T) {
 	}
 	if found == nil {
 		t.Fatal("Expected to find worktree at pr-42 path")
+		return
 	}
-	if found.PR == nil {
+	prInfo := found.PR
+	if prInfo == nil {
 		t.Fatal("Expected PR to be assigned to worktree")
+		return
 	}
-	if found.PR.Number != 42 {
-		t.Errorf("Expected PR number 42, got %d", found.PR.Number)
+	if prInfo.Number != 42 {
+		t.Errorf("Expected PR number 42, got %d", prInfo.Number)
 	}
 	if found.PRFetchStatus != models.PRFetchStatusLoaded {
 		t.Errorf("Expected PRFetchStatus to be %q, got %q", models.PRFetchStatusLoaded, found.PRFetchStatus)
@@ -363,9 +366,12 @@ func TestHandleWorktreesLoadedAssignsPendingPRToOriginalPath(t *testing.T) {
 	}
 	if prWt == nil || otherWt == nil {
 		t.Fatal("Expected to find both PR and non-PR worktrees")
+		return
 	}
-	if prWt.PR == nil || prWt.PR.Number != 42 {
+	prInfo := prWt.PR
+	if prInfo == nil || prInfo.Number != 42 {
 		t.Fatal("Expected pending PR to be assigned to original PR path")
+		return
 	}
 	if otherWt.PR != nil {
 		t.Fatal("Expected non-PR worktree to remain without PR metadata")

--- a/internal/app/render_components.go
+++ b/internal/app/render_components.go
@@ -102,7 +102,8 @@ func (m *Model) renderFooter(layout layoutDims) string {
 	case paneGitStatus: // Git Status pane
 		actionGroup := []string{m.renderKeyHint("j/k", "Scroll")}
 		if len(m.state.data.statusFiles) > 0 {
-			actionGroup = append(actionGroup,
+			actionGroup = append(
+				actionGroup,
 				m.renderKeyHint("Enter", "Show Diff"),
 				m.renderKeyHint("e", "Edit File"),
 				m.renderKeyHint("s", "Stage"),

--- a/internal/app/screen/confirm.go
+++ b/internal/app/screen/confirm.go
@@ -142,7 +142,8 @@ func (s *ConfirmScreen) View() string {
 		cancelButton = focusedCancelStyle.Render("[Cancel]")
 	}
 
-	content := fmt.Sprintf("%s\n\n%s  %s",
+	content := fmt.Sprintf(
+		"%s\n\n%s  %s",
 		messageStyle.Render(s.Message),
 		confirmButton,
 		cancelButton,

--- a/internal/app/screen/help.go
+++ b/internal/app/screen/help.go
@@ -176,6 +176,7 @@ Supported: Letters (a-z, A-Z), numbers (0-9), and hyphens (-). See help for full
 - Command palette: Open commit screen (for staged changes, or prompt to stage all)
 - Commit screen: Ctrl+G opens it from anywhere, and c opens it from the status pane; subject stays on the first line, body below; Tab switches field, Enter moves from subject to body, Ctrl+S saves, Ctrl+O auto-generates, Ctrl+X opens the external editor when configured
 - Custom commands prefixed with _: appear in the command palette only
+- CLI automation: use lazyworktree doctor --json, lazyworktree worktrees resolve, and lazyworktree describe from the shell
 - ?: Show this help
 
 **{{HELP_REPO_OPS}}Repository Operations**

--- a/internal/app/screen/info.go
+++ b/internal/app/screen/info.go
@@ -69,7 +69,8 @@ func (s *InfoScreen) View() string {
 		Background(s.Thm.Accent).
 		Bold(true)
 
-	content := fmt.Sprintf("%s\n\n%s",
+	content := fmt.Sprintf(
+		"%s\n\n%s",
 		messageStyle.Render(s.Message),
 		okStyle.Render("[OK]"),
 	)

--- a/internal/app/screen/loading.go
+++ b/internal/app/screen/loading.go
@@ -296,7 +296,8 @@ func (s *LoadingScreen) View() string {
 	}
 	tipBody := formatTipBody(s.Tip, width-8, 2)
 
-	content := lipgloss.JoinVertical(lipgloss.Center,
+	content := lipgloss.JoinVertical(
+		lipgloss.Center,
 		spinnerStyle.Render(spinnerFrame),
 		"",
 		messageStyle.Render(s.Message),

--- a/internal/app/screen/palette.go
+++ b/internal/app/screen/palette.go
@@ -749,7 +749,8 @@ func (s *CommandPaletteScreen) View() string {
 		Width((width - 4) / 2).
 		Align(lipgloss.Right)
 
-	footer := lipgloss.JoinHorizontal(lipgloss.Top,
+	footer := lipgloss.JoinHorizontal(
+		lipgloss.Top,
 		leftStyle.Render(countText),
 		rightStyle.Render(hints),
 	)

--- a/internal/app/screen/trust.go
+++ b/internal/app/screen/trust.go
@@ -103,7 +103,8 @@ func (s *TrustScreen) View() string {
 		Foreground(s.Thm.ErrorFg).
 		Render("[Cancel Operation]")
 
-	content := fmt.Sprintf("%s\n\n%s  %s  %s",
+	content := fmt.Sprintf(
+		"%s\n\n%s  %s  %s",
 		s.Viewport.View(),
 		trustButton,
 		blockButton,

--- a/internal/app/screen/welcome.go
+++ b/internal/app/screen/welcome.go
@@ -86,7 +86,8 @@ func (s *WelcomeScreen) View() string {
 		MarginTop(1).
 		Bold(true)
 
-	content := lipgloss.JoinVertical(lipgloss.Center,
+	content := lipgloss.JoinVertical(
+		lipgloss.Center,
 		titleStyle.Render("LazyWorktree"),
 		"",
 		fmt.Sprintf("%s  %s", warningStyle.Render("⚠"), warningStyle.Render("No worktrees found")),

--- a/internal/app/screens_test.go
+++ b/internal/app/screens_test.go
@@ -309,6 +309,7 @@ func TestCommitFilesScreen_GetSelectedNode(t *testing.T) {
 	node := screen.GetSelectedNode()
 	if node == nil {
 		t.Fatal("expected node, got nil")
+		return
 	}
 	if node.Path != "a.go" {
 		t.Errorf("expected path 'a.go', got %s", node.Path)

--- a/internal/app/services/agent_processes_test.go
+++ b/internal/app/services/agent_processes_test.go
@@ -127,6 +127,7 @@ func TestMatchAgentProcessesToSessionsByCWDPrefersNewest(t *testing.T) {
 	}
 	if openSession == nil {
 		t.Fatalf("expected one session to be marked open, got %#v", matched)
+		return
 	}
 	if openSession.ID != "new" {
 		t.Fatalf("expected newest session to win cwd-only match, got %q", openSession.ID)

--- a/internal/app/services/agent_sessions_test.go
+++ b/internal/app/services/agent_sessions_test.go
@@ -19,7 +19,8 @@ func TestParseClaudeSession(t *testing.T) {
 	ts := time.Now().UTC().Format(time.RFC3339Nano)
 
 	path := filepath.Join(root, "claude.jsonl")
-	writeJSONLLines(t, path,
+	writeJSONLLines(
+		t, path,
 		mustJSONLine(t, map[string]any{
 			"type":      "user",
 			"cwd":       worktreePath,
@@ -89,7 +90,8 @@ func TestParsePiSession(t *testing.T) {
 	ts := time.Now().UTC().Format(time.RFC3339Nano)
 
 	path := filepath.Join(root, "pi.jsonl")
-	writeJSONLLines(t, path,
+	writeJSONLLines(
+		t, path,
 		mustJSONLine(t, map[string]any{
 			"type":      "session",
 			"timestamp": ts,
@@ -171,7 +173,8 @@ func TestAgentSessionServiceSessionsForWorktree(t *testing.T) {
 	otherWorktree := filepath.Join(root, "worktrees", "other")
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 
-	writeJSONLLines(t, filepath.Join(claudeRoot, "project-a", "session-1.jsonl"),
+	writeJSONLLines(
+		t, filepath.Join(claudeRoot, "project-a", "session-1.jsonl"),
 		mustJSONLine(t, map[string]any{
 			"type":      "assistant",
 			"cwd":       filepath.Join(worktreePath, "subdir"),
@@ -185,7 +188,8 @@ func TestAgentSessionServiceSessionsForWorktree(t *testing.T) {
 			},
 		}),
 	)
-	writeJSONLLines(t, filepath.Join(piRoot, "project-b", "session-2.jsonl"),
+	writeJSONLLines(
+		t, filepath.Join(piRoot, "project-b", "session-2.jsonl"),
 		mustJSONLine(t, map[string]any{
 			"type":      "session",
 			"timestamp": now,
@@ -216,7 +220,8 @@ func TestAgentSessionServiceRefreshInvalidatesCache(t *testing.T) {
 	worktreePath := filepath.Join(root, "worktrees", "feature")
 	now := time.Now().UTC()
 
-	writeJSONLLines(t, sessionPath,
+	writeJSONLLines(
+		t, sessionPath,
 		mustJSONLine(t, map[string]any{
 			"type":      "assistant",
 			"cwd":       worktreePath,
@@ -241,7 +246,8 @@ func TestAgentSessionServiceRefreshInvalidatesCache(t *testing.T) {
 	}
 
 	later := now.Add(2 * time.Second)
-	writeJSONLLines(t, sessionPath,
+	writeJSONLLines(
+		t, sessionPath,
 		mustJSONLine(t, map[string]any{
 			"type":      "assistant",
 			"cwd":       worktreePath,
@@ -274,7 +280,8 @@ func TestParseClaudeSessionDecodesHyphenatedFallbackCWD(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, "claude.jsonl")
 	ts := time.Now().UTC().Format(time.RFC3339Nano)
-	writeJSONLLines(t, path,
+	writeJSONLLines(
+		t, path,
 		mustJSONLine(t, map[string]any{
 			"type":      "assistant",
 			"timestamp": ts,
@@ -306,7 +313,8 @@ func TestAgentSessionServiceRefreshFindsNestedClaudeJSONL(t *testing.T) {
 	ts := time.Now().UTC().Format(time.RFC3339Nano)
 	sessionPath := filepath.Join(claudeRoot, "project-a", "session-1", "subagents", "agent-a.jsonl")
 
-	writeJSONLLines(t, sessionPath,
+	writeJSONLLines(
+		t, sessionPath,
 		mustJSONLine(t, map[string]any{
 			"type":      "assistant",
 			"cwd":       worktreePath,
@@ -343,7 +351,8 @@ func TestParseClaudeSessionTracksNestedAgentApproval(t *testing.T) {
 	userTS := time.Now().UTC()
 	toolTS := userTS.Add(time.Second)
 
-	writeJSONLLines(t, path,
+	writeJSONLLines(
+		t, path,
 		mustJSONLine(t, map[string]any{
 			"type":      "user",
 			"cwd":       worktreePath,
@@ -420,7 +429,8 @@ func TestParseClaudeSessionIgnoresChildProgressForParentSummary(t *testing.T) {
 	path := filepath.Join(root, "claude.jsonl")
 	now := time.Now().UTC()
 
-	writeJSONLLines(t, path,
+	writeJSONLLines(
+		t, path,
 		mustJSONLine(t, map[string]any{
 			"type":      "user",
 			"cwd":       worktreePath,
@@ -476,7 +486,8 @@ func TestParseClaudeSessionNestedToolResultClearsApproval(t *testing.T) {
 	path := filepath.Join(root, "claude.jsonl")
 	now := time.Now().UTC()
 
-	writeJSONLLines(t, path,
+	writeJSONLLines(
+		t, path,
 		mustJSONLine(t, map[string]any{
 			"type":      "user",
 			"cwd":       worktreePath,
@@ -553,7 +564,8 @@ func TestParseClaudeSessionChoosesLatestPendingToolDeterministically(t *testing.
 	path := filepath.Join(root, "claude.jsonl")
 	now := time.Now().UTC()
 
-	writeJSONLLines(t, path,
+	writeJSONLLines(
+		t, path,
 		mustJSONLine(t, map[string]any{
 			"type":      "assistant",
 			"cwd":       worktreePath,

--- a/internal/app/services/note_script.go
+++ b/internal/app/services/note_script.go
@@ -35,7 +35,8 @@ func RunWorktreeNoteScript(ctx context.Context, script string, input WorktreeNot
 	// #nosec G204 -- script is user-configured and trusted
 	cmd := exec.CommandContext(ctx, "bash", "-c", script)
 	cmd.Stdin = strings.NewReader(input.Content)
-	cmd.Env = append(os.Environ(),
+	cmd.Env = append(
+		os.Environ(),
 		fmt.Sprintf("LAZYWORKTREE_TYPE=%s", input.Type),
 		fmt.Sprintf("LAZYWORKTREE_NUMBER=%d", input.Number),
 		fmt.Sprintf("LAZYWORKTREE_TITLE=%s", input.Title),

--- a/internal/app/worktree_color_picker.go
+++ b/internal/app/worktree_color_picker.go
@@ -27,7 +27,8 @@ func buildCuratedColorItems() []appscreen.SelectionItem {
 	padFmt := fmt.Sprintf("%%-%ds", maxLen)
 
 	items := make([]appscreen.SelectionItem, 0, 3+len(colors))
-	items = append(items,
+	items = append(
+		items,
 		appscreen.SelectionItem{ID: worktreeColorNoneID, Label: fmt.Sprintf(padFmt, "None"), Description: "Clear worktree colour"},
 		appscreen.SelectionItem{ID: worktreeColorCustomID, Label: fmt.Sprintf(padFmt, "Custom…"), Description: "Enter hex, supported name, or 0-255"},
 		appscreen.SelectionItem{ID: worktreeColorBoldID, Label: fmt.Sprintf(padFmt, "Bold"), Description: "Toggle bold styling"},

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -3,6 +3,7 @@ package bootstrap
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -60,6 +61,9 @@ func Run(args []string) int {
 			renameCommand(),
 			deleteCommand(),
 			listCommand(),
+			doctorCommand(),
+			worktreesCommand(),
+			notesCommand(),
 			execCommand(),
 			noteCommand(),
 			describeCommand(),
@@ -107,6 +111,17 @@ func Run(args []string) int {
 	}
 
 	if err := cliApp.Run(context.Background(), args); err != nil {
+		var exitErr interface {
+			error
+			ExitCode() int
+			Quiet() bool
+		}
+		if errors.As(err, &exitErr) {
+			if !exitErr.Quiet() && strings.TrimSpace(exitErr.Error()) != "" {
+				fmt.Fprintf(os.Stderr, "%v\n", exitErr)
+			}
+			return exitErr.ExitCode()
+		}
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		return 1
 	}

--- a/internal/bootstrap/commands_describe_test.go
+++ b/internal/bootstrap/commands_describe_test.go
@@ -18,11 +18,15 @@ func buildTestApp() *appiCli.Command {
 	app := &appiCli.Command{
 		Name:  "lazyworktree",
 		Usage: "A TUI tool to manage git worktrees",
+		Flags: globalFlags(),
 		Commands: []*appiCli.Command{
 			createCommand(),
 			renameCommand(),
 			deleteCommand(),
 			listCommand(),
+			doctorCommand(),
+			worktreesCommand(),
+			notesCommand(),
 			execCommand(),
 			noteCommand(),
 			describeCommand(),
@@ -73,6 +77,9 @@ func TestDescribeRootEmitsAllCommands(t *testing.T) {
 	assert.Contains(t, names, "delete")
 	assert.Contains(t, names, "rename")
 	assert.Contains(t, names, "list")
+	assert.Contains(t, names, "doctor")
+	assert.Contains(t, names, "worktrees")
+	assert.Contains(t, names, "notes")
 	assert.Contains(t, names, "exec")
 	assert.Contains(t, names, "note")
 	assert.Contains(t, names, "describe")

--- a/internal/bootstrap/commands_json.go
+++ b/internal/bootstrap/commands_json.go
@@ -1,5 +1,7 @@
 package bootstrap
 
+import "encoding/json"
+
 // flagDescJSON describes a single CLI flag for machine-readable introspection.
 type flagDescJSON struct {
 	Name    string   `json:"name"`
@@ -98,4 +100,104 @@ type worktreeJSONExtended struct {
 	AgentOpen     bool               `json:"agent_open"`
 	AgentActivity string             `json:"agent_activity,omitempty"`
 	AgentCount    int                `json:"agent_count"`
+}
+
+type jsonErrorEnvelope struct {
+	Error jsonError `json:"error"`
+}
+
+type jsonError struct {
+	Code    string          `json:"code"`
+	Message string          `json:"message"`
+	Details json.RawMessage `json:"details,omitempty"`
+}
+
+type doctorJSON struct {
+	Version    string           `json:"version"`
+	Build      doctorBuildJSON  `json:"build"`
+	Config     doctorConfigJSON `json:"config"`
+	Repository doctorRepoJSON   `json:"repository"`
+	Tools      doctorToolsJSON  `json:"tools"`
+	Checks     doctorChecksJSON `json:"checks"`
+}
+
+type doctorBuildJSON struct {
+	Commit  string `json:"commit,omitempty"`
+	Date    string `json:"date,omitempty"`
+	BuiltBy string `json:"built_by,omitempty"`
+}
+
+type doctorConfigJSON struct {
+	Path        string `json:"path,omitempty"`
+	Loaded      bool   `json:"loaded"`
+	WorktreeDir string `json:"worktree_dir,omitempty"`
+	NoteType    string `json:"note_type,omitempty"`
+	NotesPath   string `json:"notes_path,omitempty"`
+}
+
+type doctorRepoJSON struct {
+	CWD             string `json:"cwd"`
+	GitTopLevel     string `json:"git_top_level,omitempty"`
+	Repo            string `json:"repo,omitempty"`
+	Host            string `json:"host,omitempty"`
+	MainWorktree    string `json:"main_worktree,omitempty"`
+	CurrentWorktree string `json:"current_worktree,omitempty"`
+	InWorktree      bool   `json:"in_worktree"`
+	WorktreeCount   int    `json:"worktree_count"`
+}
+
+type doctorToolJSON struct {
+	Available bool   `json:"available"`
+	Path      string `json:"path,omitempty"`
+}
+
+type doctorToolsJSON struct {
+	Git  doctorToolJSON `json:"git"`
+	GH   doctorToolJSON `json:"gh"`
+	GLab doctorToolJSON `json:"glab"`
+}
+
+type doctorChecksJSON struct {
+	CanListWorktrees bool   `json:"can_list_worktrees"`
+	ConfigError      string `json:"config_error,omitempty"`
+	WorktreeError    string `json:"worktree_error,omitempty"`
+}
+
+type machineWorktreeJSON struct {
+	Path          string   `json:"path"`
+	Name          string   `json:"name"`
+	Branch        string   `json:"branch"`
+	Repo          string   `json:"repo"`
+	IsMain        bool     `json:"is_main"`
+	Dirty         bool     `json:"dirty"`
+	Ahead         int      `json:"ahead"`
+	Behind        int      `json:"behind"`
+	Unpushed      int      `json:"unpushed,omitempty"`
+	LastActive    string   `json:"last_active,omitempty"`
+	Description   string   `json:"description,omitempty"`
+	Tags          []string `json:"tags,omitempty"`
+	NotePresent   bool     `json:"note_present"`
+	NoteUpdatedAt int64    `json:"note_updated_at,omitempty"`
+	AgentCount    int      `json:"agent_count"`
+	AgentOpen     bool     `json:"agent_open"`
+	AgentActivity string   `json:"agent_activity,omitempty"`
+}
+
+type machineWorktreeListJSON struct {
+	Repo  string                `json:"repo"`
+	Count int                   `json:"count"`
+	Limit int                   `json:"limit,omitempty"`
+	Items []machineWorktreeJSON `json:"items"`
+}
+
+type machineWorktreeResolveJSON struct {
+	Input      string              `json:"input"`
+	ResolvedBy string              `json:"resolved_by"`
+	Worktree   machineWorktreeJSON `json:"worktree"`
+}
+
+type machineWorktreeContextJSON struct {
+	Worktree      machineWorktreeJSON `json:"worktree"`
+	Note          *noteShowJSON       `json:"note,omitempty"`
+	AgentSessions []agentSessionJSON  `json:"agent_sessions,omitempty"`
 }

--- a/internal/bootstrap/commands_machine.go
+++ b/internal/bootstrap/commands_machine.go
@@ -1,0 +1,829 @@
+package bootstrap
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/chmouel/lazyworktree/internal/app/services"
+	"github.com/chmouel/lazyworktree/internal/buildinfo"
+	"github.com/chmouel/lazyworktree/internal/config"
+	"github.com/chmouel/lazyworktree/internal/git"
+	"github.com/chmouel/lazyworktree/internal/models"
+	appiCli "github.com/urfave/cli/v3"
+)
+
+type commandExitError struct {
+	err      error
+	exitCode int
+	quiet    bool
+}
+
+func (e *commandExitError) Error() string {
+	if e == nil || e.err == nil {
+		return ""
+	}
+	return e.err.Error()
+}
+
+func (e *commandExitError) Unwrap() error { return e.err }
+
+func (e *commandExitError) ExitCode() int {
+	if e == nil || e.exitCode == 0 {
+		return 1
+	}
+	return e.exitCode
+}
+
+func (e *commandExitError) Quiet() bool { return e != nil && e.quiet }
+
+type resolvedWorktree struct {
+	worktree   *models.WorktreeInfo
+	resolvedBy string
+}
+
+type worktreeReadDeps struct {
+	cfg      *config.AppConfig
+	repoKey  string
+	notesMap map[string]models.WorktreeNote
+	agentSvc *services.AgentSessionService
+}
+
+func doctorCommand() *appiCli.Command {
+	return &appiCli.Command{
+		Name:  "doctor",
+		Usage: "Report CLI, repository, and tooling health for automation",
+		Flags: []appiCli.Flag{
+			&appiCli.BoolFlag{
+				Name:  "json",
+				Usage: "Output result as JSON",
+			},
+		},
+		Action: handleDoctorAction,
+	}
+}
+
+func worktreesCommand() *appiCli.Command {
+	return &appiCli.Command{
+		Name:  "worktrees",
+		Usage: "Discover and inspect worktrees with stable machine-readable output",
+		Commands: []*appiCli.Command{
+			worktreesListCommand(),
+			worktreesResolveCommand(),
+			worktreesGetCommand(),
+			worktreesContextCommand(),
+		},
+	}
+}
+
+func worktreesListCommand() *appiCli.Command {
+	return &appiCli.Command{
+		Name:  "list",
+		Usage: "List worktrees for the current repository",
+		Flags: []appiCli.Flag{
+			&appiCli.BoolFlag{
+				Name:  "json",
+				Usage: "Output result as JSON",
+			},
+			&appiCli.BoolFlag{
+				Name:  "main",
+				Usage: "Show only the main worktree",
+			},
+			&appiCli.IntFlag{
+				Name:  "limit",
+				Usage: "Limit the number of returned worktrees",
+			},
+			&appiCli.BoolFlag{
+				Name:  "no-agent",
+				Usage: "Skip agent session data",
+			},
+		},
+		Action: handleWorktreesListAction,
+	}
+}
+
+func worktreesResolveCommand() *appiCli.Command {
+	return &appiCli.Command{
+		Name:  "resolve",
+		Usage: "Resolve a worktree name, path, or cwd to its canonical path",
+		Flags: []appiCli.Flag{
+			&appiCli.BoolFlag{
+				Name:  "json",
+				Usage: "Output result as JSON",
+			},
+			&appiCli.StringFlag{
+				Name:  "name",
+				Usage: "Resolve a worktree by name, basename, or branch",
+			},
+			&appiCli.StringFlag{
+				Name:  "path",
+				Usage: "Resolve a worktree by absolute path or a path inside it",
+			},
+			&appiCli.StringFlag{
+				Name:  "cwd",
+				Usage: "Resolve a worktree from the provided working directory",
+			},
+			&appiCli.BoolFlag{
+				Name:  "no-agent",
+				Usage: "Skip agent session data",
+			},
+		},
+		Action: handleWorktreesResolveAction,
+	}
+}
+
+func worktreesGetCommand() *appiCli.Command {
+	return &appiCli.Command{
+		Name:      "get",
+		Usage:     "Read one exact worktree by canonical path, name, or branch",
+		ArgsUsage: "<worktree>",
+		ShellComplete: func(ctx context.Context, cmd *appiCli.Command) {
+			if cmd.NArg() == 0 {
+				outputCompletionLines(listSubcommandWorktreeNamesFunc(ctx, cmd))
+			}
+		},
+		Flags: []appiCli.Flag{
+			&appiCli.BoolFlag{
+				Name:  "json",
+				Usage: "Output result as JSON",
+			},
+			&appiCli.BoolFlag{
+				Name:  "no-agent",
+				Usage: "Skip agent session data",
+			},
+		},
+		Action: handleWorktreesGetAction,
+	}
+}
+
+func worktreesContextCommand() *appiCli.Command {
+	return &appiCli.Command{
+		Name:      "context",
+		Usage:     "Read note and agent-session context for one worktree",
+		ArgsUsage: "<worktree>",
+		ShellComplete: func(ctx context.Context, cmd *appiCli.Command) {
+			if cmd.NArg() == 0 {
+				outputCompletionLines(listSubcommandWorktreeNamesFunc(ctx, cmd))
+			}
+		},
+		Flags: []appiCli.Flag{
+			&appiCli.BoolFlag{
+				Name:  "json",
+				Usage: "Output result as JSON",
+			},
+			&appiCli.StringFlag{
+				Name:  "include",
+				Usage: "Comma-separated context sections: notes,agents (default: notes,agents)",
+				Value: "notes,agents",
+			},
+		},
+		Action: handleWorktreesContextAction,
+	}
+}
+
+func notesCommand() *appiCli.Command {
+	return &appiCli.Command{
+		Name:  "notes",
+		Usage: "Read worktree notes with machine-readable output",
+		Commands: []*appiCli.Command{
+			notesGetCommand(),
+		},
+	}
+}
+
+func notesGetCommand() *appiCli.Command {
+	return &appiCli.Command{
+		Name:      "get",
+		Usage:     "Read the note for one worktree",
+		ArgsUsage: "<worktree>",
+		ShellComplete: func(ctx context.Context, cmd *appiCli.Command) {
+			if cmd.NArg() == 0 {
+				outputCompletionLines(listSubcommandWorktreeNamesFunc(ctx, cmd))
+			}
+		},
+		Flags: []appiCli.Flag{
+			&appiCli.BoolFlag{
+				Name:  "json",
+				Usage: "Output result as JSON including metadata",
+			},
+		},
+		Action: handleNotesGetAction,
+	}
+}
+
+func handleDoctorAction(ctx context.Context, cmd *appiCli.Command) error {
+	cfg, cfgErr := loadCLIConfigFunc(
+		cmd.String("config-file"),
+		cmd.String("worktree-dir"),
+		cmd.StringSlice("config"),
+	)
+	if cfg == nil {
+		cfg = config.DefaultConfig()
+	}
+
+	gitSvc := newCLIGitServiceFunc(cfg)
+	cwd, _ := os.Getwd()
+	topLevel := gitToplevel()
+	worktrees, wtErr := gitSvc.GetWorktrees(ctx)
+	if wtErr != nil {
+		worktrees = nil
+	}
+
+	currentWorktree := detectWorktreeFromPath(cwd, worktrees)
+	mainWorktree := gitSvc.GetMainWorktreePath(ctx)
+
+	buildinfo.Enrich()
+	payload := doctorJSON{
+		Version: buildinfo.Version(),
+		Build: doctorBuildJSON{
+			Commit:  buildinfo.Commit(),
+			Date:    buildinfo.Date(),
+			BuiltBy: buildinfo.BuiltBy(),
+		},
+		Config: doctorConfigJSON{
+			Path:        cfg.ConfigPath,
+			Loaded:      strings.TrimSpace(cfg.ConfigPath) != "",
+			WorktreeDir: cfg.WorktreeDir,
+			NoteType:    cfg.WorktreeNoteType,
+			NotesPath:   cfg.WorktreeNotesPath,
+		},
+		Repository: doctorRepoJSON{
+			CWD:             cwd,
+			GitTopLevel:     topLevel,
+			Repo:            repoNameOrEmpty(gitSvc.ResolveRepoName(ctx)),
+			Host:            emptyWhenUnknown(gitSvc.DetectHost(ctx)),
+			MainWorktree:    mainWorktree,
+			InWorktree:      currentWorktree != nil,
+			WorktreeCount:   len(worktrees),
+			CurrentWorktree: pathOrEmpty(currentWorktree),
+		},
+		Tools: doctorToolsJSON{
+			Git:  doctorToolStatus("git"),
+			GH:   doctorToolStatus("gh"),
+			GLab: doctorToolStatus("glab"),
+		},
+		Checks: doctorChecksJSON{
+			CanListWorktrees: wtErr == nil,
+		},
+	}
+	if cfgErr != nil {
+		payload.Checks.ConfigError = cfgErr.Error()
+	}
+	if wtErr != nil {
+		payload.Checks.WorktreeError = wtErr.Error()
+	}
+
+	if cmd.Bool("json") {
+		return encodeJSON(os.Stdout, payload)
+	}
+
+	fmt.Fprintf(os.Stdout, "Version: %s\n", payload.Version)
+	if payload.Config.Loaded {
+		fmt.Fprintf(os.Stdout, "Config: %s\n", payload.Config.Path)
+	} else {
+		fmt.Fprintln(os.Stdout, "Config: defaults only")
+	}
+	if payload.Repository.GitTopLevel != "" {
+		fmt.Fprintf(os.Stdout, "Repository: %s\n", payload.Repository.GitTopLevel)
+	} else {
+		fmt.Fprintln(os.Stdout, "Repository: not detected")
+	}
+	if payload.Repository.CurrentWorktree != "" {
+		fmt.Fprintf(os.Stdout, "Worktree: %s\n", payload.Repository.CurrentWorktree)
+	}
+	fmt.Fprintf(os.Stdout, "Tools: git=%t gh=%t glab=%t\n", payload.Tools.Git.Available, payload.Tools.GH.Available, payload.Tools.GLab.Available)
+	if payload.Checks.ConfigError != "" {
+		fmt.Fprintf(os.Stdout, "Config warning: %s\n", payload.Checks.ConfigError)
+	}
+	if payload.Checks.WorktreeError != "" {
+		fmt.Fprintf(os.Stdout, "Worktree warning: %s\n", payload.Checks.WorktreeError)
+	}
+	return nil
+}
+
+func handleWorktreesListAction(ctx context.Context, cmd *appiCli.Command) error {
+	state, err := loadWorktreeCommandState(ctx, cmd, !cmd.Bool("no-agent"))
+	if err != nil {
+		return writeMaybeJSONError(cmd.Bool("json"), "config_error", err, nil)
+	}
+
+	worktrees := slices.Clone(state.worktrees)
+	sortWorktreesByPath(worktrees)
+	if cmd.Bool("main") {
+		worktrees = filterMainWorktrees(worktrees)
+	}
+	if limit := cmd.Int("limit"); limit > 0 && len(worktrees) > limit {
+		worktrees = worktrees[:limit]
+	}
+
+	items := make([]machineWorktreeJSON, 0, len(worktrees))
+	for _, wt := range worktrees {
+		items = append(items, buildMachineWorktreeJSON(wt, state.deps))
+	}
+
+	if cmd.Bool("json") {
+		return encodeJSON(os.Stdout, machineWorktreeListJSON{
+			Repo:  state.repoKey,
+			Count: len(items),
+			Limit: cmd.Int("limit"),
+			Items: items,
+		})
+	}
+
+	return outputMachineWorktreesTable(items)
+}
+
+func handleWorktreesResolveAction(ctx context.Context, cmd *appiCli.Command) error {
+	input, kind, err := validateResolveFlags(cmd)
+	if err != nil {
+		return writeMaybeJSONError(cmd.Bool("json"), "invalid_input", err, nil)
+	}
+
+	state, err := loadWorktreeCommandState(ctx, cmd, !cmd.Bool("no-agent"))
+	if err != nil {
+		return writeMaybeJSONError(cmd.Bool("json"), "config_error", err, nil)
+	}
+
+	resolved, err := resolveWorktreeForMachine(state.cfg, state.repoKey, state.mainWorktree, state.worktrees, input, kind)
+	if err != nil {
+		return writeMaybeJSONError(cmd.Bool("json"), "worktree_not_found", err, map[string]string{"input": input})
+	}
+
+	view := buildMachineWorktreeJSON(resolved.worktree, state.deps)
+	if cmd.Bool("json") {
+		return encodeJSON(os.Stdout, machineWorktreeResolveJSON{
+			Input:      input,
+			ResolvedBy: resolved.resolvedBy,
+			Worktree:   view,
+		})
+	}
+
+	fmt.Println(view.Path)
+	return nil
+}
+
+func handleWorktreesGetAction(ctx context.Context, cmd *appiCli.Command) error {
+	if cmd.NArg() != 1 {
+		return writeMaybeJSONError(cmd.Bool("json"), "invalid_input", fmt.Errorf("expected exactly one worktree argument"), nil)
+	}
+
+	state, err := loadWorktreeCommandState(ctx, cmd, !cmd.Bool("no-agent"))
+	if err != nil {
+		return writeMaybeJSONError(cmd.Bool("json"), "config_error", err, nil)
+	}
+
+	resolved, err := resolveWorktreeForMachine(state.cfg, state.repoKey, state.mainWorktree, state.worktrees, cmd.Args().Get(0), "name")
+	if err != nil {
+		return writeMaybeJSONError(cmd.Bool("json"), "worktree_not_found", err, nil)
+	}
+
+	view := buildMachineWorktreeJSON(resolved.worktree, state.deps)
+	if cmd.Bool("json") {
+		return encodeJSON(os.Stdout, view)
+	}
+
+	return outputMachineWorktreesTable([]machineWorktreeJSON{view})
+}
+
+func handleWorktreesContextAction(ctx context.Context, cmd *appiCli.Command) error {
+	if cmd.NArg() != 1 {
+		return writeMaybeJSONError(cmd.Bool("json"), "invalid_input", fmt.Errorf("expected exactly one worktree argument"), nil)
+	}
+
+	includeNotes, includeAgents := parseIncludeFlags(cmd.String("include"))
+	if !includeNotes && !includeAgents {
+		return writeMaybeJSONError(cmd.Bool("json"), "invalid_input", fmt.Errorf("--include must contain notes, agents, or both"), nil)
+	}
+
+	state, err := loadWorktreeCommandState(ctx, cmd, includeAgents)
+	if err != nil {
+		return writeMaybeJSONError(cmd.Bool("json"), "config_error", err, nil)
+	}
+
+	resolved, err := resolveWorktreeForMachine(state.cfg, state.repoKey, state.mainWorktree, state.worktrees, cmd.Args().Get(0), "name")
+	if err != nil {
+		return writeMaybeJSONError(cmd.Bool("json"), "worktree_not_found", err, nil)
+	}
+
+	payload := machineWorktreeContextJSON{
+		Worktree: buildMachineWorktreeJSON(resolved.worktree, state.deps),
+	}
+	if includeNotes {
+		payload.Note = buildNoteJSON(state.cfg, state.repoKey, state.deps.notesMap, resolved.worktree)
+	}
+	if includeAgents {
+		payload.AgentSessions = buildAgentSessionJSONs(state.deps.agentSvc, resolved.worktree.Path)
+	}
+
+	if cmd.Bool("json") {
+		return encodeJSON(os.Stdout, payload)
+	}
+
+	fmt.Fprintf(os.Stdout, "Path: %s\n", payload.Worktree.Path)
+	fmt.Fprintf(os.Stdout, "Branch: %s\n", payload.Worktree.Branch)
+	if payload.Note != nil && strings.TrimSpace(payload.Note.Note) != "" {
+		fmt.Fprintf(os.Stdout, "\nNote:\n%s\n", payload.Note.Note)
+	}
+	if len(payload.AgentSessions) > 0 {
+		fmt.Fprintln(os.Stdout, "\nAgent sessions:")
+		for _, session := range payload.AgentSessions {
+			fmt.Fprintf(os.Stdout, "- %s %s %s\n", session.Agent, session.Status, session.TaskLabel)
+		}
+	}
+	return nil
+}
+
+func handleNotesGetAction(ctx context.Context, cmd *appiCli.Command) error {
+	if cmd.NArg() != 1 {
+		return writeMaybeJSONError(cmd.Bool("json"), "invalid_input", fmt.Errorf("expected exactly one worktree argument"), nil)
+	}
+
+	state, err := loadWorktreeCommandState(ctx, cmd, false)
+	if err != nil {
+		return writeMaybeJSONError(cmd.Bool("json"), "config_error", err, nil)
+	}
+
+	resolved, err := resolveWorktreeForMachine(state.cfg, state.repoKey, state.mainWorktree, state.worktrees, cmd.Args().Get(0), "name")
+	if err != nil {
+		return writeMaybeJSONError(cmd.Bool("json"), "worktree_not_found", err, nil)
+	}
+
+	note := buildNoteJSON(state.cfg, state.repoKey, state.deps.notesMap, resolved.worktree)
+	if note == nil {
+		note = &noteShowJSON{
+			WorktreeName: filepath.Base(resolved.worktree.Path),
+			Path:         resolved.worktree.Path,
+		}
+	}
+
+	if cmd.Bool("json") {
+		return encodeJSON(os.Stdout, note)
+	}
+
+	if strings.TrimSpace(note.Note) != "" {
+		fmt.Print(note.Note)
+		if !strings.HasSuffix(note.Note, "\n") {
+			fmt.Println()
+		}
+	}
+	return nil
+}
+
+type worktreeCommandState struct {
+	cfg          *config.AppConfig
+	gitSvc       *git.Service
+	repoKey      string
+	worktrees    []*models.WorktreeInfo
+	mainWorktree string
+	deps         worktreeReadDeps
+}
+
+func loadWorktreeCommandState(ctx context.Context, cmd *appiCli.Command, includeAgents bool) (*worktreeCommandState, error) {
+	cfg, err := loadCLIConfigFunc(
+		cmd.String("config-file"),
+		cmd.String("worktree-dir"),
+		cmd.StringSlice("config"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	gitSvc := newCLIGitServiceFunc(cfg)
+	worktrees, err := gitSvc.GetWorktrees(ctx)
+	if err != nil {
+		return nil, err
+	}
+	sortWorktreesByPath(worktrees)
+
+	repoKey := gitSvc.ResolveRepoName(ctx)
+	mainWorktree := gitSvc.GetMainWorktreePath(ctx)
+	deps := worktreeReadDeps{
+		cfg:     cfg,
+		repoKey: repoKey,
+	}
+	if mainEnv := buildMainWorktreeEnv(ctx, gitSvc, worktrees, repoKey); mainEnv != nil {
+		deps.notesMap, _ = services.LoadWorktreeNotes(repoKey, cfg.WorktreeDir, cfg.WorktreeNotesPath, cfg.WorktreeNoteType, mainEnv)
+	}
+	if includeAgents {
+		agentSvc := services.NewAgentSessionService(nil)
+		_, _ = agentSvc.Refresh()
+		deps.agentSvc = agentSvc
+	}
+
+	return &worktreeCommandState{
+		cfg:          cfg,
+		gitSvc:       gitSvc,
+		repoKey:      repoKey,
+		worktrees:    worktrees,
+		mainWorktree: mainWorktree,
+		deps:         deps,
+	}, nil
+}
+
+func validateResolveFlags(cmd *appiCli.Command) (string, string, error) {
+	options := []struct {
+		kind  string
+		value string
+	}{
+		{kind: "name", value: strings.TrimSpace(cmd.String("name"))},
+		{kind: "path", value: strings.TrimSpace(cmd.String("path"))},
+		{kind: "cwd", value: strings.TrimSpace(cmd.String("cwd"))},
+	}
+	var chosen []struct {
+		kind  string
+		value string
+	}
+	for _, option := range options {
+		if option.value != "" {
+			chosen = append(chosen, option)
+		}
+	}
+	if len(chosen) != 1 {
+		return "", "", fmt.Errorf("specify exactly one of --name, --path, or --cwd")
+	}
+	return chosen[0].value, chosen[0].kind, nil
+}
+
+func resolveWorktreeForMachine(cfg *config.AppConfig, repoKey, mainWorktree string, worktrees []*models.WorktreeInfo, input, kind string) (*resolvedWorktree, error) {
+	switch kind {
+	case "cwd":
+		for _, wt := range worktrees {
+			if wt.Path == input || strings.HasPrefix(input, wt.Path+string(filepath.Separator)) {
+				return &resolvedWorktree{worktree: wt, resolvedBy: "cwd"}, nil
+			}
+		}
+		return nil, fmt.Errorf("worktree not found for cwd: %s", input)
+	case "path":
+		for _, wt := range worktrees {
+			if wt.Path == input {
+				return &resolvedWorktree{worktree: wt, resolvedBy: "path"}, nil
+			}
+		}
+		for _, wt := range worktrees {
+			if strings.HasPrefix(input, wt.Path+string(filepath.Separator)) {
+				return &resolvedWorktree{worktree: wt, resolvedBy: "path-prefix"}, nil
+			}
+		}
+		return nil, fmt.Errorf("worktree not found for path: %s", input)
+	default:
+		for _, wt := range worktrees {
+			if wt.Branch == input {
+				return &resolvedWorktree{worktree: wt, resolvedBy: "branch"}, nil
+			}
+		}
+		constructedPath := filepath.Join(resolveMachineWorktreeBaseDir(cfg.WorktreeDir, mainWorktree, repoKey), input)
+		for _, wt := range worktrees {
+			if wt.Path == constructedPath {
+				return &resolvedWorktree{worktree: wt, resolvedBy: "constructed-path"}, nil
+			}
+		}
+		for _, wt := range worktrees {
+			if filepath.Base(wt.Path) == input {
+				return &resolvedWorktree{worktree: wt, resolvedBy: "basename"}, nil
+			}
+		}
+		for _, wt := range worktrees {
+			if wt.Path == input {
+				return &resolvedWorktree{worktree: wt, resolvedBy: "path"}, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("worktree not found: %s", input)
+}
+
+func buildMachineWorktreeJSON(wt *models.WorktreeInfo, deps worktreeReadDeps) machineWorktreeJSON {
+	view := machineWorktreeJSON{
+		Path:       wt.Path,
+		Name:       filepath.Base(wt.Path),
+		Branch:     wt.Branch,
+		Repo:       deps.repoKey,
+		IsMain:     wt.IsMain,
+		Dirty:      wt.Dirty,
+		Ahead:      wt.Ahead,
+		Behind:     wt.Behind,
+		Unpushed:   wt.Unpushed,
+		LastActive: wt.LastActive,
+	}
+
+	if deps.notesMap != nil && deps.cfg != nil {
+		if note, ok := findNoteForWorktree(deps.cfg, deps.repoKey, deps.notesMap, wt.Path); ok {
+			view.NotePresent = true
+			view.NoteUpdatedAt = note.UpdatedAt
+			view.Description = note.Description
+			view.Tags = note.Tags
+		}
+	}
+
+	if deps.agentSvc != nil {
+		sessions := deps.agentSvc.SessionsForWorktree(wt.Path)
+		view.AgentCount = len(sessions)
+		for _, session := range sessions {
+			if session.IsOpen {
+				view.AgentOpen = true
+				view.AgentActivity = string(session.Activity)
+			}
+		}
+	}
+
+	return view
+}
+
+func buildNoteJSON(cfg *config.AppConfig, repoKey string, notesMap map[string]models.WorktreeNote, wt *models.WorktreeInfo) *noteShowJSON {
+	if notesMap == nil || cfg == nil || wt == nil {
+		return nil
+	}
+
+	note, ok := findNoteForWorktree(cfg, repoKey, notesMap, wt.Path)
+	if !ok {
+		return nil
+	}
+
+	return &noteShowJSON{
+		WorktreeName: filepath.Base(wt.Path),
+		Path:         wt.Path,
+		Note:         note.Note,
+		Description:  note.Description,
+		Icon:         note.Icon,
+		Tags:         note.Tags,
+		UpdatedAt:    note.UpdatedAt,
+	}
+}
+
+func buildAgentSessionJSONs(agentSvc *services.AgentSessionService, wtPath string) []agentSessionJSON {
+	if agentSvc == nil {
+		return nil
+	}
+
+	sessions := agentSvc.SessionsForWorktree(wtPath)
+	if len(sessions) == 0 {
+		return nil
+	}
+
+	output := make([]agentSessionJSON, 0, len(sessions))
+	for _, session := range sessions {
+		output = append(output, agentSessionJSON{
+			ID:           session.ID,
+			Agent:        string(session.Agent),
+			Status:       string(session.Status),
+			Activity:     string(session.Activity),
+			IsOpen:       session.IsOpen,
+			LastActivity: session.LastActivity.Format("2006-01-02T15:04:05Z07:00"),
+			TaskLabel:    session.TaskLabel,
+			Model:        session.Model,
+		})
+	}
+	return output
+}
+
+func parseIncludeFlags(raw string) (bool, bool) {
+	var includeNotes, includeAgents bool
+	for _, part := range strings.Split(raw, ",") {
+		switch strings.TrimSpace(strings.ToLower(part)) {
+		case "notes":
+			includeNotes = true
+		case "agents":
+			includeAgents = true
+		}
+	}
+	return includeNotes, includeAgents
+}
+
+func outputMachineWorktreesTable(items []machineWorktreeJSON) error {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "NAME\tBRANCH\tSTATUS\tLAST ACTIVE\tPATH")
+	for i := range items {
+		item := &items[i]
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", item.Name, item.Branch, buildMachineStatusString(item), item.LastActive, item.Path)
+	}
+	return w.Flush()
+}
+
+func buildMachineStatusString(item *machineWorktreeJSON) string {
+	var parts []string
+	if item.Dirty {
+		parts = append(parts, "~")
+	} else {
+		parts = append(parts, "✓")
+	}
+	if item.Behind > 0 {
+		parts = append(parts, fmt.Sprintf("↓%d", item.Behind))
+	}
+	if item.Ahead > 0 {
+		parts = append(parts, fmt.Sprintf("↑%d", item.Ahead))
+	}
+	if item.Unpushed > 0 {
+		parts = append(parts, fmt.Sprintf("?%d", item.Unpushed))
+	}
+	return strings.Join(parts, "")
+}
+
+func filterMainWorktrees(worktrees []*models.WorktreeInfo) []*models.WorktreeInfo {
+	filtered := make([]*models.WorktreeInfo, 0, 1)
+	for _, wt := range worktrees {
+		if wt.IsMain {
+			filtered = append(filtered, wt)
+		}
+	}
+	return filtered
+}
+
+func doctorToolStatus(name string) doctorToolJSON {
+	path, err := exec.LookPath(name)
+	if err != nil {
+		return doctorToolJSON{}
+	}
+	return doctorToolJSON{Available: true, Path: path}
+}
+
+func detectWorktreeFromPath(path string, worktrees []*models.WorktreeInfo) *models.WorktreeInfo {
+	for _, wt := range worktrees {
+		if wt.Path == path || strings.HasPrefix(path, wt.Path+string(filepath.Separator)) {
+			return wt
+		}
+	}
+	return nil
+}
+
+func emptyWhenUnknown(v string) string {
+	if v == "" || v == "unknown" {
+		return ""
+	}
+	return v
+}
+
+func repoNameOrEmpty(v string) string {
+	if v == "" || v == "unknown" {
+		return ""
+	}
+	return v
+}
+
+func pathOrEmpty(wt *models.WorktreeInfo) string {
+	if wt == nil {
+		return ""
+	}
+	return wt.Path
+}
+
+func resolveMachineWorktreeBaseDir(worktreeDir, mainWorktreePath, repoName string) string {
+	if mainWorktreePath != "" && worktreeDir != "" && strings.HasPrefix(filepath.Clean(worktreeDir)+string(filepath.Separator), filepath.Clean(mainWorktreePath)+string(filepath.Separator)) {
+		return worktreeDir
+	}
+	return filepath.Join(worktreeDir, repoName)
+}
+
+func findNoteForWorktree(cfg *config.AppConfig, repoKey string, notesMap map[string]models.WorktreeNote, wtPath string) (models.WorktreeNote, bool) {
+	noteKey := worktreeNoteKey(cfg, repoKey, wtPath)
+	note, ok := notesMap[noteKey]
+	if ok {
+		return note, true
+	}
+	if cfg.WorktreeNoteType != config.NoteTypeSplitted && strings.TrimSpace(cfg.WorktreeNotesPath) != "" {
+		note, ok = notesMap[filepath.Clean(wtPath)]
+	}
+	return note, ok
+}
+
+func encodeJSON(w *os.File, v any) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}
+
+func writeMaybeJSONError(jsonOutput bool, code string, err error, details any) error {
+	if !jsonOutput {
+		return err
+	}
+	if err != nil && err.Error() != "" {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+	}
+
+	payload := jsonErrorEnvelope{
+		Error: jsonError{
+			Code:    code,
+			Message: err.Error(),
+			Details: marshalJSONDetails(details),
+		},
+	}
+	if encodeErr := encodeJSON(os.Stdout, payload); encodeErr != nil {
+		return encodeErr
+	}
+	return &commandExitError{err: err, exitCode: 1, quiet: true}
+}
+
+func marshalJSONDetails(details any) json.RawMessage {
+	if details == nil {
+		return nil
+	}
+	data, err := json.Marshal(details)
+	if err != nil {
+		return nil
+	}
+	return json.RawMessage(data)
+}

--- a/internal/bootstrap/commands_machine.go
+++ b/internal/bootstrap/commands_machine.go
@@ -511,7 +511,11 @@ func loadWorktreeCommandState(ctx context.Context, cmd *appiCli.Command, include
 		deps.notesMap, _ = services.LoadWorktreeNotes(repoKey, cfg.WorktreeDir, cfg.WorktreeNotesPath, cfg.WorktreeNoteType, mainEnv)
 	}
 	if includeAgents {
-		agentSvc := services.NewAgentSessionService(nil)
+		agentSvc := services.NewAgentSessionServiceFromConfig(
+			cfg.AgentSessionClaudeRoot,
+			cfg.AgentSessionPiRoot,
+			nil,
+		)
 		_, _ = agentSvc.Refresh()
 		deps.agentSvc = agentSvc
 	}

--- a/internal/bootstrap/commands_machine_test.go
+++ b/internal/bootstrap/commands_machine_test.go
@@ -1,0 +1,239 @@
+package bootstrap
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/chmouel/lazyworktree/internal/config"
+	"github.com/chmouel/lazyworktree/internal/git"
+	"github.com/chmouel/lazyworktree/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appiCli "github.com/urfave/cli/v3"
+)
+
+func TestDoctorJSONReportsRepository(t *testing.T) {
+	repoRoot, worktreeRoot, _, _ := initMachineTestRepo(t)
+
+	output, errOutput, err := runMachineCommand(t, repoRoot, []string{
+		"lazyworktree",
+		"--worktree-dir", worktreeRoot,
+		"doctor",
+		"--json",
+	})
+	require.NoError(t, err, errOutput)
+
+	var payload doctorJSON
+	require.NoError(t, json.Unmarshal(output, &payload))
+	assert.True(t, payload.Tools.Git.Available)
+	assert.Equal(t, normalizePathForTest(t, repoRoot), payload.Repository.GitTopLevel)
+	assert.Equal(t, 2, payload.Repository.WorktreeCount)
+	assert.True(t, payload.Checks.CanListWorktrees)
+}
+
+func TestWorktreesResolveAndNotesGetJSON(t *testing.T) {
+	repoRoot, worktreeRoot, featurePath, gitSvc := initMachineTestRepo(t)
+	_ = resolveRepoKeyForTest(t, repoRoot, gitSvc)
+
+	resolveOutput, errOutput, err := runMachineCommand(t, repoRoot, []string{
+		"lazyworktree",
+		"--worktree-dir", worktreeRoot,
+		"worktrees",
+		"resolve",
+		"--name", "feature",
+		"--json",
+	})
+	require.NoError(t, err, errOutput)
+
+	var resolved machineWorktreeResolveJSON
+	require.NoError(t, json.Unmarshal(resolveOutput, &resolved))
+	assert.Equal(t, normalizePathForTest(t, featurePath), resolved.Worktree.Path)
+	assert.Equal(t, "feature", resolved.Worktree.Name)
+	assert.Equal(t, "branch", resolved.ResolvedBy)
+
+	noteOutput, noteErrOutput, err := runMachineCommand(t, repoRoot, []string{
+		"lazyworktree",
+		"--worktree-dir", worktreeRoot,
+		"notes",
+		"get",
+		"feature",
+		"--json",
+	})
+	require.NoError(t, err, noteErrOutput)
+
+	var note noteShowJSON
+	require.NoError(t, json.Unmarshal(noteOutput, &note))
+	assert.Equal(t, normalizePathForTest(t, featurePath), note.Path)
+	assert.Equal(t, "feature", note.WorktreeName)
+	assert.Empty(t, note.Note)
+}
+
+func initMachineTestRepo(t *testing.T) (string, string, string, *git.Service) {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	repoRoot := filepath.Join(tempDir, "repo")
+	worktreeRoot := filepath.Join(tempDir, "worktrees")
+	featurePath := filepath.Join(worktreeRoot, "feature")
+
+	require.NoError(t, os.MkdirAll(repoRoot, 0o750))
+	require.NoError(t, os.MkdirAll(worktreeRoot, 0o750))
+
+	runGit(t, repoRoot, "init")
+	runGit(t, repoRoot, "config", "user.name", "Lazy Worktree Test")
+	runGit(t, repoRoot, "config", "user.email", "lazyworktree@example.com")
+	runGit(t, repoRoot, "branch", "-m", "main")
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "README.md"), []byte("hello\n"), 0o600))
+	runGit(t, repoRoot, "add", "README.md")
+	runGit(t, repoRoot, "commit", "-m", "initial commit")
+	runGit(t, repoRoot, "branch", "feature")
+	runGit(t, repoRoot, "worktree", "add", featurePath, "feature")
+
+	repoRoot = normalizePathForTest(t, repoRoot)
+	worktreeRoot = normalizePathForTest(t, worktreeRoot)
+	featurePath = normalizePathForTest(t, featurePath)
+
+	gitSvc := git.NewService(nil, nil)
+	return repoRoot, worktreeRoot, featurePath, gitSvc
+}
+
+func resolveRepoKeyForTest(t *testing.T, cwd string, gitSvc *git.Service) string {
+	t.Helper()
+
+	oldWD, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(cwd))
+	defer func() {
+		_ = os.Chdir(oldWD)
+	}()
+
+	return gitSvc.ResolveRepoName(context.Background())
+}
+
+func normalizePathForTest(t *testing.T, path string) string {
+	t.Helper()
+
+	normalized, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return path
+	}
+	return normalized
+}
+
+func runGit(t *testing.T, cwd string, args ...string) {
+	t.Helper()
+	// #nosec G204 -- test helper executes controlled git commands against temp repositories.
+	cmd := exec.Command("git", args...)
+	cmd.Dir = cwd
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+}
+
+func runMachineCommand(t *testing.T, cwd string, args []string) ([]byte, string, error) {
+	t.Helper()
+
+	app := &appiCli.Command{
+		Name:  "lazyworktree",
+		Usage: "A TUI tool to manage git worktrees",
+		Flags: globalFlags(),
+		Commands: []*appiCli.Command{
+			doctorCommand(),
+			worktreesCommand(),
+			notesCommand(),
+		},
+	}
+
+	oldWD, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(cwd))
+	t.Cleanup(func() {
+		_ = os.Chdir(oldWD)
+	})
+
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	outR, outW, err := os.Pipe()
+	require.NoError(t, err)
+	errR, errW, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = outW
+	os.Stderr = errW
+	t.Cleanup(func() {
+		os.Stdout = oldStdout
+		os.Stderr = oldStderr
+		_ = outW.Close()
+		_ = outR.Close()
+		_ = errW.Close()
+		_ = errR.Close()
+	})
+
+	runErr := app.Run(context.Background(), args)
+
+	require.NoError(t, outW.Close())
+	require.NoError(t, errW.Close())
+
+	var outBuf bytes.Buffer
+	var errBuf bytes.Buffer
+	_, _ = io.Copy(&outBuf, outR)
+	_, _ = io.Copy(&errBuf, errR)
+
+	return outBuf.Bytes(), errBuf.String(), runErr
+}
+
+func TestBuildNoteJSONSupportsLegacySharedKey(t *testing.T) {
+	cfg := &config.AppConfig{
+		WorktreeDir:       "/tmp/worktrees",
+		WorktreeNotesPath: "/tmp/shared-notes.json",
+	}
+	wtPath := "/tmp/worktrees/repo/feature"
+	note := models.WorktreeNote{Note: "legacy", UpdatedAt: 1}
+
+	got := buildNoteJSON(cfg, "repo/name", map[string]models.WorktreeNote{
+		filepath.Clean(wtPath): note,
+	}, &models.WorktreeInfo{Path: wtPath})
+
+	require.NotNil(t, got)
+	assert.Equal(t, "legacy", got.Note)
+}
+
+func TestWriteMaybeJSONErrorEnvelope(t *testing.T) {
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	outR, outW, err := os.Pipe()
+	require.NoError(t, err)
+	errR, errW, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = outW
+	os.Stderr = errW
+	t.Cleanup(func() {
+		os.Stdout = oldStdout
+		os.Stderr = oldStderr
+		_ = outW.Close()
+		_ = outR.Close()
+		_ = errW.Close()
+		_ = errR.Close()
+	})
+
+	runErr := writeMaybeJSONError(true, "invalid_input", assert.AnError, map[string]string{"flag": "name"})
+	require.Error(t, runErr)
+
+	require.NoError(t, outW.Close())
+	require.NoError(t, errW.Close())
+
+	var outBuf bytes.Buffer
+	var errBuf bytes.Buffer
+	_, _ = io.Copy(&outBuf, outR)
+	_, _ = io.Copy(&errBuf, errR)
+
+	var envelope jsonErrorEnvelope
+	require.NoError(t, json.Unmarshal(outBuf.Bytes(), &envelope))
+	assert.Equal(t, "invalid_input", envelope.Error.Code)
+	assert.Contains(t, envelope.Error.Message, assert.AnError.Error())
+	assert.Contains(t, errBuf.String(), assert.AnError.Error())
+}

--- a/internal/bootstrap/commands_machine_test.go
+++ b/internal/bootstrap/commands_machine_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/chmouel/lazyworktree/internal/config"
 	"github.com/chmouel/lazyworktree/internal/git"
@@ -72,6 +73,67 @@ func TestWorktreesResolveAndNotesGetJSON(t *testing.T) {
 	assert.Equal(t, normalizePathForTest(t, featurePath), note.Path)
 	assert.Equal(t, "feature", note.WorktreeName)
 	assert.Empty(t, note.Note)
+}
+
+func TestWorktreesContextUsesConfiguredAgentRoots(t *testing.T) {
+	repoRoot, worktreeRoot, featurePath, _ := initMachineTestRepo(t)
+
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	claudeRoot := filepath.Join(tempHome, "custom-claude")
+	sessionDir := filepath.Join(claudeRoot, "project-a")
+	sessionPath := filepath.Join(sessionDir, "session-1.jsonl")
+	require.NoError(t, os.MkdirAll(sessionDir, 0o750))
+
+	ts := time.Now().UTC().Format(time.RFC3339Nano)
+	lines := []map[string]any{
+		{
+			"type":      "user",
+			"cwd":       featurePath,
+			"timestamp": ts,
+			"message": map[string]any{
+				"role":    "user",
+				"content": "Inspect machine output",
+			},
+		},
+		{
+			"type":      "assistant",
+			"cwd":       featurePath,
+			"timestamp": ts,
+			"message": map[string]any{
+				"role":  "assistant",
+				"model": "claude-sonnet-4",
+				"content": []map[string]any{
+					{"type": "tool_use", "name": "Read", "input": map[string]any{"file_path": filepath.Join(featurePath, "README.md")}},
+				},
+			},
+		},
+	}
+	writeJSONLLinesForTest(t, sessionPath, lines...)
+
+	configPath := filepath.Join(tempHome, "lazyworktree.yml")
+	configBody := []byte("agent_sessions:\n  claude_root: " + claudeRoot + "\n")
+	require.NoError(t, os.WriteFile(configPath, configBody, 0o600))
+
+	output, errOutput, err := runMachineCommand(t, repoRoot, []string{
+		"lazyworktree",
+		"--config-file", configPath,
+		"--worktree-dir", worktreeRoot,
+		"worktrees",
+		"context",
+		"feature",
+		"--include", "agents",
+		"--json",
+	})
+	require.NoError(t, err, errOutput)
+
+	var payload machineWorktreeContextJSON
+	require.NoError(t, json.Unmarshal(output, &payload))
+	require.Len(t, payload.AgentSessions, 1)
+	assert.Equal(t, "session-1", payload.AgentSessions[0].ID)
+	assert.Equal(t, "claude", payload.AgentSessions[0].Agent)
+	assert.Equal(t, "feature", payload.Worktree.Name)
 }
 
 func initMachineTestRepo(t *testing.T) (string, string, string, *git.Service) {
@@ -184,6 +246,20 @@ func runMachineCommand(t *testing.T, cwd string, args []string) ([]byte, string,
 	_, _ = io.Copy(&errBuf, errR)
 
 	return outBuf.Bytes(), errBuf.String(), runErr
+}
+
+func writeJSONLLinesForTest(t *testing.T, path string, entries ...map[string]any) {
+	t.Helper()
+
+	var payload bytes.Buffer
+	for _, entry := range entries {
+		line, err := json.Marshal(entry)
+		require.NoError(t, err)
+		payload.Write(line)
+		payload.WriteByte('\n')
+	}
+
+	require.NoError(t, os.WriteFile(path, payload.Bytes(), 0o600))
 }
 
 func TestBuildNoteJSONSupportsLegacySharedKey(t *testing.T) {

--- a/internal/cli/operations.go
+++ b/internal/cli/operations.go
@@ -349,7 +349,8 @@ func runBranchNameScript(ctx context.Context, script, content, scriptType, numbe
 	// #nosec G204 -- script is user-configured and trusted
 	cmd := exec.CommandContext(scriptCtx, "bash", "-c", script)
 	cmd.Stdin = strings.NewReader(content)
-	cmd.Env = append(os.Environ(),
+	cmd.Env = append(
+		os.Environ(),
 		fmt.Sprintf("LAZYWORKTREE_TYPE=%s", scriptType),
 		fmt.Sprintf("LAZYWORKTREE_NUMBER=%s", number),
 		fmt.Sprintf("LAZYWORKTREE_TEMPLATE=%s", template),
@@ -398,14 +399,16 @@ func CreateFromIssueWithFS(ctx context.Context, gitSvc gitService, cfg *config.A
 	branchName := utils.GenerateIssueWorktreeName(selectedIssue, template, "")
 
 	if noWorkspace {
-		if !gitSvc.RunCommandChecked(ctx,
+		if !gitSvc.RunCommandChecked(
+			ctx,
 			[]string{"git", "branch", branchName, baseBranch},
 			"",
 			fmt.Sprintf("Failed to create branch from issue #%d", issueNumber),
 		) {
 			return "", fmt.Errorf("failed to create branch from issue #%d", issueNumber)
 		}
-		if !gitSvc.RunCommandChecked(ctx,
+		if !gitSvc.RunCommandChecked(
+			ctx,
 			[]string{"git", "switch", branchName},
 			"",
 			fmt.Sprintf("Failed to switch to branch %s", branchName),
@@ -434,7 +437,8 @@ func CreateFromIssueWithFS(ctx context.Context, gitSvc gitService, cfg *config.A
 	}
 
 	// Create worktree from base branch
-	if !gitSvc.RunCommandChecked(ctx,
+	if !gitSvc.RunCommandChecked(
+		ctx,
 		[]string{"git", "worktree", "add", "-b", branchName, targetPath, baseBranch},
 		"",
 		fmt.Sprintf("Failed to create worktree from issue #%d", issueNumber),

--- a/lazyworktree.1
+++ b/lazyworktree.1
@@ -335,6 +335,48 @@ Output the note as a JSON object containing worktree_name, path, note, descripti
 .B \-\-input \fIFILE\fR, \-i \fIFILE\fR
 Read the note from a file instead of opening an editor. Use \fB\-\fR to read from stdin. The input format is the same frontmatter+markdown used by the editor.
 .
+.SS doctor
+Report CLI, repository, and helper tool health for automation.
+.
+.PP
+The doctor command is designed for coding agents and scripts. It reports configuration loading, repository detection, worktree visibility, and helper tool availability without requiring the full TUI.
+.
+.PP
+.B Options:
+.TP
+.B \-\-json
+Output the diagnostic result as JSON. Setup gaps are reported in the payload rather than causing a hard failure.
+.
+.SS worktrees
+Discover, resolve, and inspect worktrees with stable machine-readable output.
+.
+.PP
+.B Subcommands:
+.TP
+.B list
+List worktrees for the current repository. Supports \fB\-\-json\fR, \fB\-\-main\fR, \fB\-\-limit\fR, and \fB\-\-no\-agent\fR.
+.
+.TP
+.B resolve
+Resolve a worktree name, branch, path, or cwd into a canonical worktree path. Supports \fB\-\-name\fR, \fB\-\-path\fR, \fB\-\-cwd\fR, and \fB\-\-json\fR.
+.
+.TP
+.B get \fIWORKTREE\fR
+Read one exact worktree by canonical path, branch, or basename. Supports \fB\-\-json\fR.
+.
+.TP
+.B context \fIWORKTREE\fR
+Read note and agent-session context for one worktree. Supports \fB\-\-include\fR and \fB\-\-json\fR.
+.
+.SS notes
+Read worktree notes with machine-readable output.
+.
+.PP
+.B Subcommands:
+.TP
+.B get \fIWORKTREE\fR
+Return note metadata for one exact worktree. Use \fB\-\-json\fR for a stable payload containing worktree_name, path, note, description, icon, tags, and updated_at.
+.
 .SS describe
 Emit the CLI command structure as machine-readable JSON. Designed for coding agents and scripts that need to discover flags and subcommands without parsing \-\-help output.
 .
@@ -376,6 +418,31 @@ List only the main branch worktree:
 List only the main branch worktree as JSON:
 .br
 .B lazyworktree list \-\-main \-\-json
+.
+.PP
+Inspect CLI and repository health for automation:
+.br
+.B lazyworktree doctor \-\-json
+.
+.PP
+Resolve a worktree name to its canonical path:
+.br
+.B lazyworktree worktrees resolve \-\-name my\-feature \-\-json
+.
+.PP
+Read one exact worktree as JSON:
+.br
+.B lazyworktree worktrees get my\-feature \-\-json
+.
+.PP
+Read worktree context as JSON:
+.br
+.B lazyworktree worktrees context my\-feature \-\-json
+.
+.PP
+Read note metadata as JSON:
+.br
+.B lazyworktree notes get my\-feature \-\-json
 .
 .PP
 Create from current branch (auto-generated name):

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,6 +118,9 @@ nav:
       - Overview: cli/overview.md
       - Commands Reference: cli/commands.md
       - Flags Reference: cli/flags.md
+      - doctor: cli/doctor.md
+      - worktrees: cli/worktrees.md
+      - notes: cli/notes.md
       - list: cli/list.md
       - create: cli/create.md
       - delete: cli/delete.md


### PR DESCRIPTION
## What changed

Added machine-readable CLI entry points for automation with `lazyworktree doctor`, `lazyworktree worktrees ...`, and `lazyworktree notes get`, and extended the existing JSON support and command discovery metadata around them.

Updated the generated references, man page, CLI overview pages, AI integration guide, and in-app help so the new automation workflow is documented consistently.

## Why it changed

Scripts and coding agents previously had to rely on limited JSON output or parse human-oriented help text to discover repository health, resolve worktrees, and read note metadata. This change gives them stable read APIs directly in the CLI.

## Impact

Users can now inspect repository and tooling health, resolve worktrees deterministically, and fetch note metadata in stable JSON without launching the TUI. The docs now point automation users to `describe`, `doctor`, `worktrees`, and `notes get` as the preferred machine-first workflow.

## Validation

- `make sanity`
- `make docs-check`
- repository pre-push checks including `golangci`, `gofumpt`, `docs-sync check`, and `go test`