### PR TITLE
fix: load custom themes on startup

### DIFF
--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -294,14 +294,14 @@ func applyThemeConfig(cfg *config.AppConfig, themeName string) error {
 		return nil
 	}
 
-	normalized := config.NormalizeThemeName(themeName)
+	normalized := config.NormalizeConfiguredThemeName(themeName, cfg.CustomThemes)
 	if normalized == "" {
 		return fmt.Errorf("unknown theme %q", themeName)
 	}
 
 	cfg.Theme = normalized
 	if !cfg.GitPagerArgsSet && filepath.Base(cfg.GitPager) == "delta" {
-		cfg.GitPagerArgs = config.DefaultDeltaArgsForTheme(normalized)
+		cfg.GitPagerArgs = config.DefaultDeltaArgsForConfiguredTheme(normalized, cfg.CustomThemes)
 	}
 
 	return nil

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -249,6 +249,29 @@ func TestApplyThemeConfig(t *testing.T) {
 	}
 }
 
+func TestApplyThemeConfigAcceptsConfiguredCustomTheme(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.GitPager = "delta"
+	cfg.CustomThemes = map[string]*config.CustomTheme{
+		"catppuccin-frappe": {
+			Base:   "catppuccin-mocha",
+			Accent: "#FF6B9D",
+		},
+	}
+
+	err := applyThemeConfig(cfg, "catppuccin-frappe")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Theme != "catppuccin-frappe" {
+		t.Fatalf("expected custom theme, got %q", cfg.Theme)
+	}
+	if got, want := strings.Join(cfg.GitPagerArgs, " "), "--syntax-theme \"Catppuccin Mocha\""; got != want {
+		t.Fatalf("expected custom theme to inherit delta args %q, got %q", want, got)
+	}
+}
+
 func TestLoadCLIConfig(t *testing.T) {
 	t.Run("load default config", func(t *testing.T) {
 		cfg, err := loadCLIConfig("", "", nil)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -281,21 +281,6 @@ func parseConfig(data map[string]any) (*AppConfig, error) {
 		}
 	}
 
-	if themeName, ok := data["theme"].(string); ok {
-		if normalized := NormalizeThemeName(themeName); normalized != "" {
-			cfg.Theme = normalized
-		}
-	}
-
-	if !cfg.GitPagerArgsSet {
-		if filepath.Base(cfg.GitPager) == "delta" {
-			cfg.GitPagerArgs = DefaultDeltaArgsForTheme(cfg.Theme)
-		} else {
-			// Clear delta args inherited from DefaultConfig when using non-delta pager
-			cfg.GitPagerArgs = nil
-		}
-	}
-
 	cfg.GitPagerInteractive = coerceBool(data["git_pager_interactive"], false)
 	cfg.GitPagerCommandMode = coerceBool(data["git_pager_command_mode"], false)
 
@@ -414,6 +399,21 @@ func parseConfig(data map[string]any) (*AppConfig, error) {
 
 	if _, ok := data["custom_themes"]; ok {
 		cfg.CustomThemes = parseCustomThemes(data)
+	}
+
+	if themeName, ok := data["theme"].(string); ok {
+		if normalized := NormalizeConfiguredThemeName(themeName, cfg.CustomThemes); normalized != "" {
+			cfg.Theme = normalized
+		}
+	}
+
+	if !cfg.GitPagerArgsSet {
+		if filepath.Base(cfg.GitPager) == "delta" {
+			cfg.GitPagerArgs = DefaultDeltaArgsForConfiguredTheme(cfg.Theme, cfg.CustomThemes)
+		} else {
+			// Clear delta args inherited from DefaultConfig when using non-delta pager
+			cfg.GitPagerArgs = nil
+		}
 	}
 
 	if _, ok := data["layout_sizes"]; ok {
@@ -539,8 +539,10 @@ func (cfg *AppConfig) ApplyCLIOverrides(overrides []string) error {
 	if overrideCfg.SortMode != "" {
 		cfg.SortMode = overrideCfg.SortMode
 	}
-	if overrideCfg.Theme != "" {
-		cfg.Theme = overrideCfg.Theme
+	if themeName, ok := overrideData["theme"].(string); ok {
+		if normalized := NormalizeConfiguredThemeName(themeName, cfg.CustomThemes); normalized != "" {
+			cfg.Theme = normalized
+		}
 	}
 	if overrideCfg.GitPager != "" {
 		cfg.GitPager = overrideCfg.GitPager
@@ -759,7 +761,7 @@ func LoadConfig(configPath string) (*AppConfig, error) {
 
 		if !cfg.GitPagerArgsSet {
 			if filepath.Base(cfg.GitPager) == "delta" {
-				cfg.GitPagerArgs = DefaultDeltaArgsForTheme(cfg.Theme)
+				cfg.GitPagerArgs = DefaultDeltaArgsForConfiguredTheme(cfg.Theme, cfg.CustomThemes)
 			} else {
 				cfg.GitPagerArgs = nil
 			}

--- a/internal/config/config_display.go
+++ b/internal/config/config_display.go
@@ -340,11 +340,65 @@ func DefaultDeltaArgsForTheme(themeName string) []string {
 	}
 }
 
+// DefaultDeltaArgsForConfiguredTheme returns the default delta arguments for a
+// built-in theme, or for the built-in base of a custom theme.
+func DefaultDeltaArgsForConfiguredTheme(themeName string, customThemes map[string]*CustomTheme) []string {
+	normalized := NormalizeThemeName(themeName)
+	if normalized != "" {
+		return DefaultDeltaArgsForTheme(normalized)
+	}
+
+	customName := NormalizeConfiguredThemeName(themeName, customThemes)
+	if customName == "" {
+		return DefaultDeltaArgsForTheme(themeName)
+	}
+
+	visited := make(map[string]bool)
+	for {
+		if visited[customName] {
+			return DefaultDeltaArgsForTheme(themeName)
+		}
+		visited[customName] = true
+
+		customTheme, ok := customThemes[customName]
+		if !ok || customTheme == nil {
+			return DefaultDeltaArgsForTheme(themeName)
+		}
+
+		baseName := NormalizeThemeName(customTheme.Base)
+		if baseName != "" {
+			return DefaultDeltaArgsForTheme(baseName)
+		}
+
+		nextCustomName := NormalizeConfiguredThemeName(customTheme.Base, customThemes)
+		if nextCustomName == "" {
+			return DefaultDeltaArgsForTheme(themeName)
+		}
+		customName = nextCustomName
+	}
+}
+
 // NormalizeThemeName returns the normalized theme name if valid, otherwise empty string.
 func NormalizeThemeName(name string) string {
 	name = strings.ToLower(strings.TrimSpace(name))
 	switch name {
 	case "dracula", "dracula-light", "narna", "clean-light", "catppuccin-latte", "rose-pine-dawn", "one-light", "everforest-light", "solarized-dark", "solarized-light", "gruvbox-dark", "gruvbox-light", "nord", "monokai", "catppuccin-mocha", "modern", "tokyo-night", "one-dark", "rose-pine", "ayu-mirage", "everforest-dark", "kanagawa":
+		return name
+	}
+	return ""
+}
+
+// NormalizeConfiguredThemeName returns the normalized theme name if it is a
+// built-in theme or one of the configured custom themes.
+func NormalizeConfiguredThemeName(name string, customThemes map[string]*CustomTheme) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+	if name == "" {
+		return ""
+	}
+	if normalized := NormalizeThemeName(name); normalized != "" {
+		return normalized
+	}
+	if _, ok := customThemes[name]; ok {
 		return name
 	}
 	return ""

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1572,6 +1572,32 @@ func TestLoadConfigWithCustomPath(t *testing.T) {
 	assert.Equal(t, customConfigPath, cfg.ConfigPath)
 }
 
+func TestLoadConfigWithCustomThemeDefault(t *testing.T) {
+	defer func() { gitConfigMock = nil }()
+	gitConfigMock = func(args []string, repoPath string) (string, error) {
+		return "", nil
+	}
+
+	tempDir := t.TempDir()
+	customConfigPath := filepath.Join(tempDir, "custom-theme.yaml")
+	customConfigContent := `theme: catppuccin-frappe
+custom_themes:
+  catppuccin-frappe:
+    base: catppuccin-mocha
+    accent: "#FF6B9D"
+`
+	err := os.WriteFile(customConfigPath, []byte(customConfigContent), 0o600)
+	require.NoError(t, err)
+
+	cfg, err := LoadConfig(customConfigPath)
+	require.NoError(t, err)
+
+	assert.Equal(t, "catppuccin-frappe", cfg.Theme)
+	assert.Contains(t, cfg.CustomThemes, "catppuccin-frappe")
+	assert.Equal(t, []string{"--syntax-theme", "\"Catppuccin Mocha\""}, cfg.GitPagerArgs)
+	assert.Equal(t, customConfigPath, cfg.ConfigPath)
+}
+
 func TestLoadConfigWithCustomPathFromAnywhere(t *testing.T) {
 	// Setup mock to prevent loading real git config from the test repository
 	defer func() { gitConfigMock = nil }()
@@ -1744,6 +1770,21 @@ func TestApplyCLIOverrides(t *testing.T) {
 	assert.Equal(t, "echo note", cfg.WorktreeNoteScript)
 	assert.Equal(t, "/tmp/lazyworktree-notes.json", cfg.WorktreeNotesPath)
 	assert.Equal(t, "review-{number}-{generated}", cfg.PRBranchNameTemplate)
+}
+
+func TestApplyCLIOverridesAcceptsConfiguredCustomTheme(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.CustomThemes = map[string]*CustomTheme{
+		"catppuccin-frappe": {
+			Base:   "catppuccin-mocha",
+			Accent: "#FF6B9D",
+		},
+	}
+
+	err := cfg.ApplyCLIOverrides([]string{"lw.theme=catppuccin-frappe"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "catppuccin-frappe", cfg.Theme)
 }
 
 func TestLoadConfigReadsCommitAutoGenerateCommandFromYAML(t *testing.T) {


### PR DESCRIPTION
## Summary

- Loaded configured custom themes before resolving the saved `theme:` value.
- Allowed CLI theme overrides to resolve custom theme names from the loaded configuration.
- Reused the custom theme base for default delta syntax theme arguments.

Fixes #63

## Validation

- `go test ./internal/config`
- `go test ./internal/bootstrap -run TestApplyThemeConfig`
- `golangci-lint run --fix ./internal/config ./internal/bootstrap`
- `env GIT_CONFIG_GLOBAL=/dev/null XDG_CONFIG_HOME=/tmp/lwt-empty-xdg HOME=/tmp/lwt-empty-home go test ./...`
- `make build`
- pre-push hooks passed with `GIT_CONFIG_GLOBAL=/dev/null` to avoid local signing config in temporary git repositories
