### PR TITLE
fix: refresh delta args for theme overrides

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -91,12 +91,12 @@ max_diff_chars: 200000
 #   git_pager: ""         # disables formatting
 #
 # If git_pager is delta and git_pager_args is omitted, lazyworktree automatically
-# selects a --syntax-theme matching your UI theme.
+# selects a --syntax-theme matching the final UI theme, including CLI overrides.
 git_pager: delta
 
 # Extra arguments passed to git_pager.
 # If you omit this setting and git_pager is delta, lazyworktree selects a syntax
-# theme matching your UI theme (e.g., Dracula for dark themes).
+# theme matching the final UI theme (e.g., Dracula for dark themes).
 git_pager_args:
   - --syntax-theme
   - Dracula

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -160,7 +160,7 @@ git config --local --get-regexp "^lw\."
 ### Diff, pager, and editor
 
 - `git_pager`: diff formatter (default: `delta`). Empty string disables formatting.
-- `git_pager_args`: arguments for `git_pager`. Auto-selects syntax theme for delta.
+- `git_pager_args`: arguments for `git_pager`. When omitted with `delta`, lazyworktree auto-selects a syntax theme for the final UI theme, including CLI theme overrides.
 - `git_pager_interactive`: set `true` for interactive viewers like `diffnav` or `tig`.
 - `git_pager_command_mode`: set `true` for command-based diff viewers like `lumen` that run their own git commands (for example `lumen diff`).
 - `pager`: pager for output display (default: `$PAGER`, fallback to `less`).

--- a/docs/configuration/diff-pager-and-editor.md
+++ b/docs/configuration/diff-pager-and-editor.md
@@ -7,6 +7,7 @@ Configure output viewers for diffs, logs, and file edits.
 - `git_pager`: formatter command (default `delta`)
 - empty `git_pager`: disable formatter
 - `git_pager_args`: formatter arguments
+- omitted `git_pager_args` with `delta`: auto-select syntax theme for the final UI theme, including CLI theme overrides
 
 Optional compatibility flags:
 

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -23,7 +23,7 @@ This page is generated from `internal/config/config.go`. Run `make docs-sync` af
 | `max_untracked_diffs` | `int` | `10` | Limit number of untracked file diffs rendered. |
 | `max_diff_chars` | `int` | `200000` | Maximum characters read from diff output. |
 | `git_pager` | `string` | `delta` | Diff formatter/pager command. |
-| `git_pager_args` | `[]string` | `auto-matched delta syntax theme` | Extra arguments passed to configured git pager. |
+| `git_pager_args` | `[]string` | `auto-matched delta syntax theme` | Extra arguments passed to configured git pager. Omit with delta to auto-match the final UI theme. |
 | `delta_path` | `string (legacy)` | `none` | Legacy alias for git_pager. |
 | `delta_args` | `[]string (legacy)` | `none` | Legacy alias for git_pager_args. |
 | `git_pager_interactive` | `bool` | `false` | Use interactive pager mode for terminal-native tools. |

--- a/hack/docsync/main.go
+++ b/hack/docsync/main.go
@@ -430,7 +430,7 @@ func parseConfigKeys(path string) ([]configKeySpec, error) {
 		"max_untracked_diffs":          "Limit number of untracked file diffs rendered.",
 		"max_diff_chars":               "Maximum characters read from diff output.",
 		"max_name_length":              "Maximum displayed worktree name length.",
-		"git_pager_args":               "Extra arguments passed to configured git pager.",
+		"git_pager_args":               "Extra arguments passed to configured git pager. Omit with delta to auto-match the final UI theme.",
 		"delta_args":                   "Legacy alias for git_pager_args.",
 		"git_pager":                    "Diff formatter/pager command.",
 		"delta_path":                   "Legacy alias for git_pager.",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -532,70 +532,69 @@ func (cfg *AppConfig) ApplyCLIOverrides(overrides []string) error {
 		return err
 	}
 
-	// Apply each non-zero/non-empty field from overrideCfg to cfg
-	if overrideCfg.WorktreeDir != "" {
+	// Apply each field only when the matching override was provided.
+	if _, ok := overrideData["worktree_dir"]; ok {
 		cfg.WorktreeDir = overrideCfg.WorktreeDir
 	}
-	if overrideCfg.SortMode != "" {
+	if _, ok := overrideData["sort_mode"]; ok {
 		cfg.SortMode = overrideCfg.SortMode
 	}
 	if themeName, ok := overrideData["theme"].(string); ok {
 		if normalized := NormalizeConfiguredThemeName(themeName, cfg.CustomThemes); normalized != "" {
 			cfg.Theme = normalized
-			if !cfg.GitPagerArgsSet && filepath.Base(cfg.GitPager) == "delta" {
-				cfg.GitPagerArgs = DefaultDeltaArgsForConfiguredTheme(normalized, cfg.CustomThemes)
-			}
 		}
 	}
-	if overrideCfg.GitPager != "" {
+	if _, ok := overrideData["git_pager"]; ok {
+		cfg.GitPager = overrideCfg.GitPager
+	} else if _, ok := overrideData["delta_path"]; ok {
 		cfg.GitPager = overrideCfg.GitPager
 	}
-	if overrideCfg.Pager != "" {
+	if _, ok := overrideData["pager"]; ok {
 		cfg.Pager = overrideCfg.Pager
 	}
-	if overrideCfg.CIScriptPager != "" {
+	if _, ok := overrideData["ci_script_pager"]; ok {
 		cfg.CIScriptPager = overrideCfg.CIScriptPager
 	}
-	if overrideCfg.Editor != "" {
+	if _, ok := overrideData["editor"]; ok {
 		cfg.Editor = overrideCfg.Editor
 	}
-	if overrideCfg.Commit.AutoGenerateCommand != "" {
+	if overrideNestedData(overrideData, "commit", "auto_generate_command") {
 		cfg.Commit.AutoGenerateCommand = overrideCfg.Commit.AutoGenerateCommand
 	}
-	if overrideCfg.DebugLog != "" {
+	if _, ok := overrideData["debug_log"]; ok {
 		cfg.DebugLog = overrideCfg.DebugLog
 	}
-	if overrideCfg.TrustMode != "" {
+	if _, ok := overrideData["trust_mode"]; ok {
 		cfg.TrustMode = overrideCfg.TrustMode
 	}
-	if overrideCfg.MergeMethod != "" {
+	if _, ok := overrideData["merge_method"]; ok {
 		cfg.MergeMethod = overrideCfg.MergeMethod
 	}
-	if overrideCfg.BranchNameScript != "" {
+	if _, ok := overrideData["branch_name_script"]; ok {
 		cfg.BranchNameScript = overrideCfg.BranchNameScript
 	}
-	if overrideCfg.WorktreeNoteScript != "" {
+	if _, ok := overrideData["worktree_note_script"]; ok {
 		cfg.WorktreeNoteScript = overrideCfg.WorktreeNoteScript
 	}
-	if overrideCfg.WorktreeNoteType != "" {
+	if _, ok := overrideData["worktree_note_type"]; ok {
 		cfg.WorktreeNoteType = overrideCfg.WorktreeNoteType
 	}
-	if overrideCfg.WorktreeNotesPath != "" {
+	if _, ok := overrideData["worktree_notes_path"]; ok {
 		cfg.WorktreeNotesPath = overrideCfg.WorktreeNotesPath
 	}
-	if overrideCfg.IssueBranchNameTemplate != "" {
+	if _, ok := overrideData["issue_branch_name_template"]; ok {
 		cfg.IssueBranchNameTemplate = overrideCfg.IssueBranchNameTemplate
 	}
-	if overrideCfg.PRBranchNameTemplate != "" {
+	if _, ok := overrideData["pr_branch_name_template"]; ok {
 		cfg.PRBranchNameTemplate = overrideCfg.PRBranchNameTemplate
 	}
-	if overrideCfg.SessionPrefix != "" {
+	if _, ok := overrideData["session_prefix"]; ok {
 		cfg.SessionPrefix = overrideCfg.SessionPrefix
 	}
-	if overrideCfg.AgentSessionClaudeRoot != "" {
+	if overrideNestedData(overrideData, "agent_sessions", "claude_root") {
 		cfg.AgentSessionClaudeRoot = overrideCfg.AgentSessionClaudeRoot
 	}
-	if overrideCfg.AgentSessionPiRoot != "" {
+	if overrideNestedData(overrideData, "agent_sessions", "pi_root") {
 		cfg.AgentSessionPiRoot = overrideCfg.AgentSessionPiRoot
 	}
 
@@ -607,6 +606,9 @@ func (cfg *AppConfig) ApplyCLIOverrides(overrides []string) error {
 		cfg.TerminateCommands = overrideCfg.TerminateCommands
 	}
 	if _, ok := overrideData["git_pager_args"]; ok {
+		cfg.GitPagerArgs = overrideCfg.GitPagerArgs
+		cfg.GitPagerArgsSet = true
+	} else if _, ok := overrideData["delta_args"]; ok {
 		cfg.GitPagerArgs = overrideCfg.GitPagerArgs
 		cfg.GitPagerArgsSet = true
 	}
@@ -686,7 +688,24 @@ func (cfg *AppConfig) ApplyCLIOverrides(overrides []string) error {
 		}
 	}
 
+	if !cfg.GitPagerArgsSet {
+		if filepath.Base(cfg.GitPager) == "delta" {
+			cfg.GitPagerArgs = DefaultDeltaArgsForConfiguredTheme(cfg.Theme, cfg.CustomThemes)
+		} else {
+			cfg.GitPagerArgs = nil
+		}
+	}
+
 	return nil
+}
+
+func overrideNestedData(data map[string]any, parent, key string) bool {
+	nested, ok := data[parent].(map[string]any)
+	if !ok {
+		return false
+	}
+	_, ok = nested[key]
+	return ok
 }
 
 // mergeMaps merges src map into dst map, with src values taking precedence.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -542,6 +542,9 @@ func (cfg *AppConfig) ApplyCLIOverrides(overrides []string) error {
 	if themeName, ok := overrideData["theme"].(string); ok {
 		if normalized := NormalizeConfiguredThemeName(themeName, cfg.CustomThemes); normalized != "" {
 			cfg.Theme = normalized
+			if !cfg.GitPagerArgsSet && filepath.Base(cfg.GitPager) == "delta" {
+				cfg.GitPagerArgs = DefaultDeltaArgsForConfiguredTheme(normalized, cfg.CustomThemes)
+			}
 		}
 	}
 	if overrideCfg.GitPager != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1785,6 +1785,7 @@ func TestApplyCLIOverridesAcceptsConfiguredCustomTheme(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "catppuccin-frappe", cfg.Theme)
+	assert.Equal(t, []string{"--syntax-theme", "\"Catppuccin Mocha\""}, cfg.GitPagerArgs)
 }
 
 func TestLoadConfigReadsCommitAutoGenerateCommandFromYAML(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1788,6 +1788,105 @@ func TestApplyCLIOverridesAcceptsConfiguredCustomTheme(t *testing.T) {
 	assert.Equal(t, []string{"--syntax-theme", "\"Catppuccin Mocha\""}, cfg.GitPagerArgs)
 }
 
+func TestApplyCLIOverridesThemeAndGitPagerReconcileArgs(t *testing.T) {
+	t.Run("clears default delta args when pager becomes non-delta", func(t *testing.T) {
+		cfg := DefaultConfig()
+
+		err := cfg.ApplyCLIOverrides([]string{
+			"lw.theme=nord",
+			"lw.git_pager=diff-so-fancy",
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, "nord", cfg.Theme)
+		assert.Equal(t, "diff-so-fancy", cfg.GitPager)
+		assert.Nil(t, cfg.GitPagerArgs)
+		assert.False(t, cfg.GitPagerArgsSet)
+	})
+
+	t.Run("sets default delta args when pager becomes delta", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.GitPager = "diff-so-fancy"
+		cfg.GitPagerArgs = nil
+
+		err := cfg.ApplyCLIOverrides([]string{
+			"lw.theme=nord",
+			"lw.git_pager=delta",
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, "nord", cfg.Theme)
+		assert.Equal(t, "delta", cfg.GitPager)
+		assert.Equal(t, []string{"--syntax-theme", "\"Nord\""}, cfg.GitPagerArgs)
+		assert.False(t, cfg.GitPagerArgsSet)
+	})
+
+	t.Run("keeps explicit pager args", func(t *testing.T) {
+		cfg := DefaultConfig()
+
+		err := cfg.ApplyCLIOverrides([]string{
+			"lw.theme=nord",
+			"lw.git_pager=diff-so-fancy",
+			"lw.git_pager_args=--color always",
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, "nord", cfg.Theme)
+		assert.Equal(t, "diff-so-fancy", cfg.GitPager)
+		assert.Equal(t, []string{"--color", "always"}, cfg.GitPagerArgs)
+		assert.True(t, cfg.GitPagerArgsSet)
+	})
+}
+
+func TestApplyCLIOverridesDoesNotResetUnspecifiedStringFields(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.WorktreeDir = "/existing/worktrees"
+	cfg.SortMode = "path"
+	cfg.GitPager = "diff-so-fancy"
+	cfg.GitPagerArgs = nil
+	cfg.Pager = "less -R"
+	cfg.CIScriptPager = "bat --plain"
+	cfg.Editor = "vim"
+	cfg.Commit.AutoGenerateCommand = "echo existing"
+	cfg.DebugLog = "/tmp/existing.log"
+	cfg.TrustMode = "always"
+	cfg.MergeMethod = "merge"
+	cfg.BranchNameScript = "branch-script"
+	cfg.WorktreeNoteScript = "note-script"
+	cfg.WorktreeNoteType = NoteTypeSplitted
+	cfg.WorktreeNotesPath = "/tmp/notes.json"
+	cfg.IssueBranchNameTemplate = "custom-issue-{number}"
+	cfg.PRBranchNameTemplate = "custom-pr-{number}"
+	cfg.SessionPrefix = "custom-"
+	cfg.AgentSessionClaudeRoot = "/tmp/claude"
+	cfg.AgentSessionPiRoot = "/tmp/pi"
+
+	err := cfg.ApplyCLIOverrides([]string{"lw.theme=nord"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "nord", cfg.Theme)
+	assert.Equal(t, "/existing/worktrees", cfg.WorktreeDir)
+	assert.Equal(t, "path", cfg.SortMode)
+	assert.Equal(t, "diff-so-fancy", cfg.GitPager)
+	assert.Nil(t, cfg.GitPagerArgs)
+	assert.Equal(t, "less -R", cfg.Pager)
+	assert.Equal(t, "bat --plain", cfg.CIScriptPager)
+	assert.Equal(t, "vim", cfg.Editor)
+	assert.Equal(t, "echo existing", cfg.Commit.AutoGenerateCommand)
+	assert.Equal(t, "/tmp/existing.log", cfg.DebugLog)
+	assert.Equal(t, "always", cfg.TrustMode)
+	assert.Equal(t, "merge", cfg.MergeMethod)
+	assert.Equal(t, "branch-script", cfg.BranchNameScript)
+	assert.Equal(t, "note-script", cfg.WorktreeNoteScript)
+	assert.Equal(t, NoteTypeSplitted, cfg.WorktreeNoteType)
+	assert.Equal(t, "/tmp/notes.json", cfg.WorktreeNotesPath)
+	assert.Equal(t, "custom-issue-{number}", cfg.IssueBranchNameTemplate)
+	assert.Equal(t, "custom-pr-{number}", cfg.PRBranchNameTemplate)
+	assert.Equal(t, "custom-", cfg.SessionPrefix)
+	assert.Equal(t, "/tmp/claude", cfg.AgentSessionClaudeRoot)
+	assert.Equal(t, "/tmp/pi", cfg.AgentSessionPiRoot)
+}
+
 func TestLoadConfigReadsCommitAutoGenerateCommandFromYAML(t *testing.T) {
 	tempDir := t.TempDir()
 	yamlPath := filepath.Join(tempDir, "config.yaml")

--- a/lazyworktree.1
+++ b/lazyworktree.1
@@ -1285,7 +1285,7 @@ Default: delta
 .B git_pager_args
 List of extra arguments passed to git_pager for diff rendering.
 .br
-If omitted and git_pager is delta, lazyworktree picks a syntax theme matching your UI theme.
+If omitted and git_pager is delta, lazyworktree picks a syntax theme matching the final UI theme, including CLI theme overrides.
 .br
 Default mappings: dracula → Dracula, dracula-light → Monokai Extended Light, narna → OneHalfDark, clean-light → GitHub, catppuccin-latte → Catppuccin Latte, rose-pine-dawn → GitHub, one-light → OneHalfLight, everforest-light → Gruvbox Light, solarized-dark → Solarized (dark), solarized-light → Solarized (light), gruvbox-dark → Gruvbox Dark, gruvbox-light → Gruvbox Light, nord → Nord, monokai → Monokai Extended, catppuccin-mocha → Catppuccin Mocha.
 .br


### PR DESCRIPTION
## Summary

- Refresh default delta syntax arguments when `--config lw.theme=...` changes the configured theme.
- Preserve explicit `git_pager_args` behaviour by only updating defaults when args were not user-set.
- Extend the custom theme CLI override regression test to cover inherited delta args.

Follow-up to #64.

## Validation

- `go test ./internal/config -run 'TestApplyCLIOverridesAcceptsConfiguredCustomTheme|TestApplyCLIOverrides|TestApplyCLIOverridesMultiValue'`
- `golangci-lint run --fix ./internal/config`
- `env GIT_CONFIG_GLOBAL=/dev/null XDG_CONFIG_HOME=/tmp/lwt-empty-xdg HOME=/tmp/lwt-empty-home go test ./...`
- `make build`
- pre-push hooks passed with `GIT_CONFIG_GLOBAL=/dev/null XDG_CONFIG_HOME=/tmp/lwt-empty-xdg`
