### PR TITLE
fix: disable optional locks on git operations

### DIFF
--- a/internal/git/service.go
+++ b/internal/git/service.go
@@ -37,6 +37,14 @@ const (
 // so tests can mock it and avoid depending on system binaries being installed.
 var LookupPath = exec.LookPath
 
+// OptionalLocksEnv disables git's optional locks for a subprocess. Read-only
+// commands such as `git status` and `git diff` otherwise opportunistically
+// refresh the index, writing .git/index.lock as a side effect; in a worktree
+// where a coding agent is committing, that transient lock races the agent's own
+// and intermittently fails its commit. Only optional locks are suppressed — the
+// required locks taken by real writes (commit, checkout, …) are unaffected.
+const OptionalLocksEnv = "GIT_OPTIONAL_LOCKS=0"
+
 // NotifyFn receives ongoing notifications.
 type NotifyFn func(message string, severity string)
 
@@ -106,7 +114,13 @@ func (s *Service) prepareAllowedCommand(ctx context.Context, args []string) (*ex
 	}
 
 	switch args[0] {
-	case "git", "glab", "gh":
+	case "git":
+		cmd := s.commandRunner(ctx, args[0], args[1:]...)
+		// Keep lazyworktree's background status/diff polling from taking the
+		// worktree index lock and racing a concurrent git command there.
+		cmd.Env = append(os.Environ(), OptionalLocksEnv)
+		return cmd, nil
+	case "glab", "gh":
 		return s.commandRunner(ctx, args[0], args[1:]...), nil
 	default:
 		return nil, fmt.Errorf("unsupported command %q", args[0])
@@ -344,7 +358,12 @@ func (s *Service) RunGitWithCombinedOutput(ctx context.Context, args []string, c
 		cmd.Dir = cwd
 	}
 	if len(env) > 0 {
-		cmd.Env = append(os.Environ(), formatEnv(env)...)
+		// prepareAllowedCommand already seeds cmd.Env (with GIT_OPTIONAL_LOCKS=0
+		// for git); extend that rather than os.Environ() so it isn't dropped.
+		if cmd.Env == nil {
+			cmd.Env = os.Environ()
+		}
+		cmd.Env = append(cmd.Env, formatEnv(env)...)
 	}
 
 	return cmd.CombinedOutput()

--- a/internal/git/service_optionallocks_test.go
+++ b/internal/git/service_optionallocks_test.go
@@ -1,0 +1,71 @@
+package git
+
+import (
+	"context"
+	"os/exec"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// captureRunner records every *exec.Cmd it hands back so a test can inspect the
+// environment lazyworktree prepares for a subprocess. It points the command at
+// `true` so RunGit can execute it harmlessly.
+func captureRunner(captured *[]*exec.Cmd) func(ctx context.Context, name string, args ...string) *exec.Cmd {
+	return func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+		c := exec.CommandContext(ctx, "true")
+		*captured = append(*captured, c)
+		return c
+	}
+}
+
+func envHas(cmd *exec.Cmd, kv string) bool {
+	return slices.Contains(cmd.Env, kv)
+}
+
+// Git reads run for display must never take optional locks, so lazyworktree's
+// background status/diff polling can't create .git/index.lock and race a git
+// command (e.g. an agent's commit) in the same worktree.
+func TestRunGitDisablesOptionalLocks(t *testing.T) {
+	svc := NewService(func(string, string) {}, func(string, string, string) {})
+	var captured []*exec.Cmd
+	svc.SetCommandRunner(captureRunner(&captured))
+
+	svc.RunGit(context.Background(), []string{"git", "status", "--porcelain"}, "", []int{0}, true, false)
+
+	require.Len(t, captured, 1)
+	require.True(t, envHas(captured[0], "GIT_OPTIONAL_LOCKS=0"),
+		"git subprocess env should contain GIT_OPTIONAL_LOCKS=0, got %v", captured[0].Env)
+}
+
+// The combined-output path is used for worktree writes; it must keep the
+// optional-locks setting from prepareAllowedCommand while still layering the
+// caller's own env on top.
+func TestRunGitWithCombinedOutputKeepsOptionalLocks(t *testing.T) {
+	svc := NewService(func(string, string) {}, func(string, string, string) {})
+	var captured []*exec.Cmd
+	svc.SetCommandRunner(captureRunner(&captured))
+
+	_, _ = svc.RunGitWithCombinedOutput(context.Background(),
+		[]string{"git", "pull"}, "", map[string]string{"GIT_TERMINAL_PROMPT": "0"})
+
+	require.Len(t, captured, 1)
+	require.True(t, envHas(captured[0], "GIT_OPTIONAL_LOCKS=0"),
+		"combined-output git env should retain GIT_OPTIONAL_LOCKS=0, got %v", captured[0].Env)
+	require.True(t, envHas(captured[0], "GIT_TERMINAL_PROMPT=0"),
+		"caller-supplied env should still be present, got %v", captured[0].Env)
+}
+
+// gh/glab are not git and must not be forced into the git lock setting.
+func TestNonGitCommandsNotForcedOptionalLocks(t *testing.T) {
+	svc := NewService(func(string, string) {}, func(string, string, string) {})
+	var captured []*exec.Cmd
+	svc.SetCommandRunner(captureRunner(&captured))
+
+	svc.RunGit(context.Background(), []string{"gh", "pr", "list"}, "", []int{0}, true, true)
+
+	require.Len(t, captured, 1)
+	require.False(t, envHas(captured[0], "GIT_OPTIONAL_LOCKS=0"),
+		"non-git command env should not be modified, got %v", captured[0].Env)
+}


### PR DESCRIPTION
## Problem

Coding agents running in a worktree intermittently failed `git commit` with `Unable to create '.git/index.lock': File exists`.

The cause is lazyworktree's own background polling: read-only commands like `git status` and `git diff` opportunistically refresh the index, taking git's *optional* lock and momentarily writing `.git/index.lock`. The auto-refresh/watcher polling and status pane run these in the active worktree, racing a concurrent git command (e.g. an agent's commit) for the same lock file.

## Fix

Disable git's optional locks (`GIT_OPTIONAL_LOCKS=0`) on every git subprocess spawned through the git service (`internal/git/service.go` — `RunGit` / `RunGitWithCombinedOutput`). Only *optional* locks are suppressed; the *required* locks taken by real writes (commit, checkout, pull, …) are untouched, so correctness is unaffected.

This covers all of lazyworktree's background repository reads — `status`, `diff`, `stash`, worktree listing — the high-frequency operations that raced the agent. `git config` / `git rev-parse` (in `internal/config/gitconfig.go`, `internal/bootstrap`) don't touch the index and are left as-is.

## Scope

Deliberately limited to the git **service** path. Foreground, user-initiated git (the diff-pane pager pipeline, commit-message auto-generate) is left to take normal optional locks — those are rare and user-driven, so not worth broadening the surface.

## Tests

`internal/git/service_optionallocks_test.go`:
- git subprocesses (incl. the combined-output write path) carry `GIT_OPTIONAL_LOCKS=0`
- caller-supplied env is preserved
- `gh`/`glab` are **not** affected

`make sanity` passes (lint, gofumpt, full test suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)