### PR TITLE
feat: disable git optional locks for git commands

### DIFF
--- a/internal/app/app_helpers.go
+++ b/internal/app/app_helpers.go
@@ -135,10 +135,11 @@ func nonInteractiveSSHCommand(existing, fallback string) string {
 
 func (m *Model) buildNonInteractiveGitEnv(branch, wtPath string) []string {
 	envVars := filterWorktreeEnvVars(os.Environ())
-	envVars = filterEnvVars(envVars, "GIT_TERMINAL_PROMPT", "GIT_SSH_COMMAND")
+	envVars = filterEnvVars(envVars, "GIT_OPTIONAL_LOCKS", "GIT_TERMINAL_PROMPT", "GIT_SSH_COMMAND")
 	envVars = append(envVars, envMapToList(m.buildCommandEnv(branch, wtPath))...)
 	envVars = append(
 		envVars,
+		"GIT_OPTIONAL_LOCKS=0",
 		"GIT_TERMINAL_PROMPT=0",
 		fmt.Sprintf("GIT_SSH_COMMAND=%s", nonInteractiveSSHCommand(os.Getenv("GIT_SSH_COMMAND"), os.Getenv("GIT_SSH"))),
 	)

--- a/internal/app/app_helpers_test.go
+++ b/internal/app/app_helpers_test.go
@@ -270,19 +270,30 @@ func TestBuildNonInteractiveGitEnv(t *testing.T) {
 	cfg := &config.AppConfig{WorktreeDir: t.TempDir()}
 	m := NewModel(cfg, "")
 
+	t.Setenv("GIT_OPTIONAL_LOCKS", "1")
 	t.Setenv("GIT_TERMINAL_PROMPT", "1")
 	t.Setenv("GIT_SSH_COMMAND", "ssh -F ~/.ssh/config")
 
 	env := m.buildNonInteractiveGitEnv("feature", "/tmp/wt")
 
 	values := map[string]string{}
+	optionalLocksCount := 0
 	for _, entry := range env {
 		key, value, ok := strings.Cut(entry, "=")
 		if ok {
 			values[key] = value
+			if key == "GIT_OPTIONAL_LOCKS" {
+				optionalLocksCount++
+			}
 		}
 	}
 
+	if got := values["GIT_OPTIONAL_LOCKS"]; got != "0" {
+		t.Fatalf("expected GIT_OPTIONAL_LOCKS=0, got %q", got)
+	}
+	if optionalLocksCount != 1 {
+		t.Fatalf("expected one GIT_OPTIONAL_LOCKS entry, got %d", optionalLocksCount)
+	}
 	if got := values["GIT_TERMINAL_PROMPT"]; got != "0" {
 		t.Fatalf("expected GIT_TERMINAL_PROMPT=0, got %q", got)
 	}

--- a/internal/git/service.go
+++ b/internal/git/service.go
@@ -22,6 +22,8 @@ const (
 	gitHostGithub  = "github"
 	gitHostUnknown = "unknown"
 
+	gitOptionalLocksEnv = "GIT_OPTIONAL_LOCKS=0"
+
 	// CI conclusion constants
 	ciSuccess   = "success"
 	ciFailure   = "failure"
@@ -105,14 +107,27 @@ func (s *Service) SetCommandRunner(runner func(ctx context.Context, name string,
 	s.commandRunner = runner
 }
 
-func (s *Service) prepareAllowedCommand(ctx context.Context, args []string) (*exec.Cmd, error) {
+func (s *Service) prepareAllowedCommand(ctx context.Context, args []string, env map[string]string) (*exec.Cmd, error) {
 	if len(args) == 0 {
 		return nil, fmt.Errorf("no command provided")
 	}
 
 	switch args[0] {
 	case "git", "glab", "gh":
-		return s.commandRunner(ctx, args[0], args[1:]...), nil
+		cmd := s.commandRunner(ctx, args[0], args[1:]...)
+		if len(env) > 0 {
+			if cmd.Env == nil {
+				cmd.Env = os.Environ()
+			}
+			cmd.Env = append(cmd.Env, formatEnv(env)...)
+		}
+		if args[0] == "git" {
+			if cmd.Env == nil {
+				cmd.Env = os.Environ()
+			}
+			cmd.Env = disableGitOptionalLocks(cmd.Env)
+		}
+		return cmd, nil
 	default:
 		return nil, fmt.Errorf("unsupported command %q", args[0])
 	}
@@ -235,6 +250,17 @@ func formatEnv(env map[string]string) []string {
 	return formatted
 }
 
+func disableGitOptionalLocks(env []string) []string {
+	filtered := make([]string, 0, len(env)+1)
+	for _, entry := range env {
+		if strings.HasPrefix(entry, "GIT_OPTIONAL_LOCKS=") {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return append(filtered, gitOptionalLocksEnv)
+}
+
 func (s *Service) acquireSemaphore() {
 	<-s.semaphore
 }
@@ -251,7 +277,7 @@ func (s *Service) RunGit(ctx context.Context, args []string, cwd string, okRetur
 	}
 	s.debugf("run: %s (cwd=%s)", command, cwd)
 
-	cmd, err := s.prepareAllowedCommand(ctx, args)
+	cmd, err := s.prepareAllowedCommand(ctx, args, nil)
 	if err != nil {
 		key := fmt.Sprintf("unsupported_cmd:%s", command)
 		s.notifyOnce(key, fmt.Sprintf("Unsupported command: %s", command), "error")
@@ -314,7 +340,7 @@ func (s *Service) RunCommandChecked(ctx context.Context, args []string, cwd, err
 	}
 	s.debugf("run: %s (cwd=%s)", command, cwd)
 
-	cmd, err := s.prepareAllowedCommand(ctx, args)
+	cmd, err := s.prepareAllowedCommand(ctx, args, nil)
 	if err != nil {
 		message := fmt.Sprintf("%s: %v", errorPrefix, err)
 		if errorPrefix == "" {
@@ -350,15 +376,12 @@ func (s *Service) RunGitWithCombinedOutput(ctx context.Context, args []string, c
 	command := strings.Join(args, " ")
 	s.debugf("run: %s (cwd=%s)", command, cwd)
 
-	cmd, err := s.prepareAllowedCommand(ctx, args)
+	cmd, err := s.prepareAllowedCommand(ctx, args, env)
 	if err != nil {
 		return nil, err
 	}
 	if cwd != "" {
 		cmd.Dir = cwd
-	}
-	if len(env) > 0 {
-		cmd.Env = append(os.Environ(), formatEnv(env)...)
 	}
 
 	return cmd.CombinedOutput()

--- a/internal/git/service_optionallocks_test.go
+++ b/internal/git/service_optionallocks_test.go
@@ -1,0 +1,105 @@
+package git
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const helperProcessEnv = "GO_WANT_GIT_SERVICE_HELPER_PROCESS"
+
+func TestGitServiceHelperProcess(*testing.T) {
+	if os.Getenv(helperProcessEnv) != "1" {
+		return
+	}
+	os.Exit(0)
+}
+
+func helperProcessRunner(captured **exec.Cmd, initialEnv ...string) func(context.Context, string, ...string) *exec.Cmd {
+	return func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+		cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestGitServiceHelperProcess", "--") // #nosec G204,G702 -- the test binary and arguments are controlled
+		cmd.Env = append([]string{helperProcessEnv + "=1"}, initialEnv...)
+		*captured = cmd
+		return cmd
+	}
+}
+
+func TestPrepareAllowedCommandOverridesInheritedOptionalLocks(t *testing.T) {
+	t.Setenv("GIT_OPTIONAL_LOCKS", "1")
+	service := NewService(func(string, string) {}, func(string, string, string) {})
+	service.SetCommandRunner(func(context.Context, string, ...string) *exec.Cmd {
+		return &exec.Cmd{}
+	})
+
+	cmd, err := service.prepareAllowedCommand(context.Background(), []string{"git", "status"}, nil)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"0"}, envValues(cmd.Env, "GIT_OPTIONAL_LOCKS"))
+}
+
+func envValues(env []string, key string) []string {
+	prefix := key + "="
+	values := make([]string, 0, 1)
+	for _, entry := range env {
+		if len(entry) >= len(prefix) && entry[:len(prefix)] == prefix {
+			values = append(values, entry[len(prefix):])
+		}
+	}
+	return values
+}
+
+func TestRunGitDisablesOptionalLocks(t *testing.T) {
+	service := NewService(func(string, string) {}, func(string, string, string) {})
+	var captured *exec.Cmd
+	service.SetCommandRunner(helperProcessRunner(
+		&captured,
+		"RUNNER_ENV=preserved",
+		"GIT_OPTIONAL_LOCKS=1",
+	))
+
+	service.RunGit(context.Background(), []string{"git", "status", "--porcelain"}, "", []int{0}, true, false)
+
+	require.NotNil(t, captured)
+	require.Equal(t, []string{"0"}, envValues(captured.Env, "GIT_OPTIONAL_LOCKS"))
+	require.Equal(t, []string{"preserved"}, envValues(captured.Env, "RUNNER_ENV"))
+}
+
+func TestRunGitWithCombinedOutputForcesOptionalLocks(t *testing.T) {
+	service := NewService(func(string, string) {}, func(string, string, string) {})
+	var captured *exec.Cmd
+	service.SetCommandRunner(helperProcessRunner(
+		&captured,
+		"RUNNER_ENV=preserved",
+		"GIT_OPTIONAL_LOCKS=true",
+	))
+
+	_, err := service.RunGitWithCombinedOutput(
+		context.Background(),
+		[]string{"git", "pull"},
+		"",
+		map[string]string{
+			"CALLER_ENV":         "preserved",
+			"GIT_OPTIONAL_LOCKS": "1",
+		},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, captured)
+	require.Equal(t, []string{"0"}, envValues(captured.Env, "GIT_OPTIONAL_LOCKS"))
+	require.Equal(t, []string{"preserved"}, envValues(captured.Env, "RUNNER_ENV"))
+	require.Equal(t, []string{"preserved"}, envValues(captured.Env, "CALLER_ENV"))
+}
+
+func TestNonGitCommandsKeepOptionalLocksEnvironment(t *testing.T) {
+	service := NewService(func(string, string) {}, func(string, string, string) {})
+	var captured *exec.Cmd
+	service.SetCommandRunner(helperProcessRunner(&captured, "GIT_OPTIONAL_LOCKS=1"))
+
+	service.RunGit(context.Background(), []string{"gh", "pr", "list"}, "", []int{0}, true, true)
+
+	require.NotNil(t, captured)
+	require.Equal(t, []string{"1"}, envValues(captured.Env, "GIT_OPTIONAL_LOCKS"))
+}

--- a/internal/git/service_worktree.go
+++ b/internal/git/service_worktree.go
@@ -307,7 +307,7 @@ func (s *Service) CherryPickCommit(ctx context.Context, commitSHA, targetPath st
 		return false, fmt.Errorf("target worktree has uncommitted changes")
 	}
 
-	cmd, err := s.prepareAllowedCommand(ctx, []string{"git", "cherry-pick", commitSHA})
+	cmd, err := s.prepareAllowedCommand(ctx, []string{"git", "cherry-pick", commitSHA}, nil)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Added environment variable handling to command execution to ensure
GIT_OPTIONAL_LOCKS is always set to 0 for git commands, preventing
file locking issues during concurrent operations. Non-git commands
like gh and glab preserve their original environment. The
prepareAllowedCommand method now accepts optional environment
variables that are merged with the command's environment, with git
commands receiving special handling to disable optional locks.

