### PR TITLE
perf: reduce idle CPU usage

### DIFF
--- a/cmd/lazyworktree/main.go
+++ b/cmd/lazyworktree/main.go
@@ -2,7 +2,9 @@
 package main
 
 import (
+	"fmt"
 	"os"
+	"runtime/pprof"
 
 	"github.com/chmouel/lazyworktree/internal/bootstrap"
 	"github.com/chmouel/lazyworktree/internal/buildinfo"
@@ -17,5 +19,31 @@ var (
 
 func main() {
 	buildinfo.Set(version, commit, date, builtBy)
-	os.Exit(bootstrap.Run(os.Args))
+	stopProfile := startCPUProfile()
+	code := bootstrap.Run(os.Args)
+	stopProfile()
+	os.Exit(code)
+}
+
+// startCPUProfile enables CPU profiling when LAZYWORKTREE_PPROF names a file
+// path. This is a hidden diagnostic hook for performance investigations.
+func startCPUProfile() func() {
+	path := os.Getenv("LAZYWORKTREE_PPROF")
+	if path == "" {
+		return func() {}
+	}
+	f, err := os.Create(path) // #nosec G304 -- operator-supplied diagnostics path
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to create CPU profile %q: %v\n", path, err)
+		return func() {}
+	}
+	if err := pprof.StartCPUProfile(f); err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to start CPU profile: %v\n", err)
+		_ = f.Close()
+		return func() {}
+	}
+	return func() {
+		pprof.StopCPUProfile()
+		_ = f.Close()
+	}
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -109,6 +109,7 @@ type (
 	detailsCacheEntry struct {
 		statusRaw    string
 		logRaw       string
+		headSHA      string
 		unpushedSHAs map[string]bool
 		unmergedSHAs map[string]bool
 		fetchedAt    time.Time
@@ -308,17 +309,18 @@ type uiState struct {
 }
 
 type dataState struct {
-	worktrees         []*models.WorktreeInfo
-	filteredWts       []*models.WorktreeInfo
-	selectedIndex     int
-	accessHistory     map[string]int64 // worktree path -> last access timestamp
-	statusFiles       []StatusFile     // parsed list of files from git status (kept for compatibility)
-	statusFilesAll    []StatusFile     // full list of files from git status
-	statusFileIndex   int              // currently selected file index in status pane
-	agentSessions     []*models.AgentSession
-	agentSessionIndex int
-	logEntries        []commitLogEntry
-	logEntriesAll     []commitLogEntry
+	worktrees             []*models.WorktreeInfo
+	filteredWts           []*models.WorktreeInfo
+	selectedIndex         int
+	accessHistory         map[string]int64 // worktree path -> last access timestamp
+	statusFiles           []StatusFile     // parsed list of files from git status (kept for compatibility)
+	statusFilesAll        []StatusFile     // full list of files from git status
+	statusFileIndex       int              // currently selected file index in status pane
+	agentSessions         []*models.AgentSession
+	agentSessionsSnapshot []*models.AgentSession // last full refresh result, for change detection
+	agentSessionIndex     int
+	logEntries            []commitLogEntry
+	logEntriesAll         []commitLogEntry
 }
 
 type servicesState struct {
@@ -686,7 +688,9 @@ func (m *Model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.FocusMsg:
 		m.state.view.TerminalFocused = true
 		m.debugf("terminal focused")
-		return m, m.refreshWorktrees()
+		// Resume the auto-refresh tick loop if it suspended itself while
+		// the terminal was unfocused.
+		return m, tea.Batch(m.refreshWorktrees(), m.startAutoRefresh())
 
 	case tea.BlurMsg:
 		m.state.view.TerminalFocused = false
@@ -730,8 +734,10 @@ func (m *Model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleWorktreeMessages(msg)
 
 	case agentSessionsUpdatedMsg:
-		if msg.err == nil {
-			m.state.data.agentSessions = msg.sessions
+		// Skip the pane rebuild when the refresh produced an identical
+		// snapshot, which is the common case on idle ticks.
+		if msg.err == nil && !agentSessionsEqual(m.state.data.agentSessionsSnapshot, msg.sessions) {
+			m.state.data.agentSessionsSnapshot = msg.sessions
 			m.refreshSelectedWorktreeAgentSessionsPane()
 		}
 		return m, nil
@@ -1074,12 +1080,15 @@ func (m *Model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.updateDetailsView()
 
 	case autoRefreshTickMsg:
-		// Keep scheduling ticks but skip git work when terminal is unfocused
+		// Suspend the tick loop entirely while the terminal is unfocused;
+		// the FocusMsg handler restarts it. Terminals without focus
+		// reporting never blur, so they keep the loop running.
+		if !m.state.view.TerminalFocused {
+			m.autoRefreshStarted = false
+			return m, nil
+		}
 		if cmd := m.autoRefreshTick(); cmd != nil {
 			cmds = append(cmds, cmd)
-		}
-		if !m.state.view.TerminalFocused {
-			return m, tea.Batch(cmds...)
 		}
 		if cmd := m.refreshDetails(); cmd != nil {
 			cmds = append(cmds, cmd)
@@ -1099,6 +1108,9 @@ func (m *Model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.state.services.watch.ResetWaiting()
 		cmds = append(cmds, m.waitForGitWatchEvent())
 		if m.shouldRefreshGitEvent(time.Now()) {
+			// Ref/log changes invalidate cached details (log, unpushed,
+			// unmerged), so force full refetches instead of revalidation.
+			m.resetDetailsCache()
 			cmds = append(cmds, m.refreshWorktrees())
 		}
 		return m, tea.Batch(cmds...)

--- a/internal/app/app_agents.go
+++ b/internal/app/app_agents.go
@@ -31,6 +31,26 @@ func (m *Model) agentSessionsEnabled() bool {
 	return m.config == nil || !m.config.AgentSessionsDisabled
 }
 
+// agentSessionsEqual reports whether two session snapshots carry identical
+// data, letting periodic refreshes skip state churn when nothing changed.
+func agentSessionsEqual(a, b []*models.AgentSession) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] == nil || b[i] == nil {
+			if a[i] != b[i] {
+				return false
+			}
+			continue
+		}
+		if *a[i] != *b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func (m *Model) refreshAgentSessions() tea.Cmd {
 	if !m.agentSessionsEnabled() {
 		return nil

--- a/internal/app/app_agents_test.go
+++ b/internal/app/app_agents_test.go
@@ -251,3 +251,49 @@ func TestRenderAgentSessionMarkerUsesTextGlyphForClaude(t *testing.T) {
 		t.Fatalf("expected text Claude marker, got %q", marker)
 	}
 }
+
+func TestAgentSessionsEqual(t *testing.T) {
+	now := time.Now()
+	a := &models.AgentSession{ID: "one", CWD: "/tmp/wt", Status: models.AgentSessionStatusWaitingForUser, LastActivity: now}
+	b := &models.AgentSession{ID: "one", CWD: "/tmp/wt", Status: models.AgentSessionStatusWaitingForUser, LastActivity: now}
+	c := &models.AgentSession{ID: "two", CWD: "/tmp/wt"}
+
+	if !agentSessionsEqual(nil, nil) {
+		t.Fatal("expected nil slices to be equal")
+	}
+	if !agentSessionsEqual([]*models.AgentSession{a}, []*models.AgentSession{b}) {
+		t.Fatal("expected identical session values to be equal")
+	}
+	if agentSessionsEqual([]*models.AgentSession{a}, []*models.AgentSession{c}) {
+		t.Fatal("expected differing sessions to be unequal")
+	}
+	if agentSessionsEqual([]*models.AgentSession{a}, nil) {
+		t.Fatal("expected differing lengths to be unequal")
+	}
+	if !agentSessionsEqual([]*models.AgentSession{nil}, []*models.AgentSession{nil}) {
+		t.Fatal("expected nil entries to be equal")
+	}
+	if agentSessionsEqual([]*models.AgentSession{nil}, []*models.AgentSession{a}) {
+		t.Fatal("expected nil versus value entry to be unequal")
+	}
+}
+
+func TestAgentSessionsUpdatedMsgSkipsUnchangedSnapshot(t *testing.T) {
+	cfg := &config.AppConfig{WorktreeDir: t.TempDir()}
+	m := NewModel(cfg, "")
+
+	current := []*models.AgentSession{{ID: "one", CWD: "/tmp/wt"}}
+	m.state.data.agentSessionsSnapshot = current
+
+	clone := []*models.AgentSession{{ID: "one", CWD: "/tmp/wt"}}
+	_, _ = m.Update(agentSessionsUpdatedMsg{sessions: clone})
+	if &m.state.data.agentSessionsSnapshot[0] != &current[0] {
+		t.Fatal("expected unchanged snapshot to keep existing state")
+	}
+
+	changed := []*models.AgentSession{{ID: "two", CWD: "/tmp/wt"}}
+	_, _ = m.Update(agentSessionsUpdatedMsg{sessions: changed})
+	if m.state.data.agentSessionsSnapshot[0].ID != "two" {
+		t.Fatal("expected changed snapshot to replace state")
+	}
+}

--- a/internal/app/app_nav.go
+++ b/internal/app/app_nav.go
@@ -372,8 +372,10 @@ func (m *Model) updateDetailsView() tea.Cmd {
 		}
 		return nil
 	}
+	// Capture on the UI thread; the returned command runs in a goroutine.
+	allowRevalidate := m.gitWatcherActive()
 	return func() tea.Msg {
-		statusRaw, logRaw, unpushed, unmerged := m.getCachedDetails(wt)
+		statusRaw, logRaw, unpushed, unmerged := m.getCachedDetails(wt, allowRevalidate)
 
 		// Parse log
 		logEntries := []commitLogEntry{}

--- a/internal/app/app_status.go
+++ b/internal/app/app_status.go
@@ -376,21 +376,46 @@ func (m *Model) resetDetailsCache() {
 	m.cache.detailsCache = make(map[string]*detailsCacheEntry)
 }
 
-func (m *Model) getCachedDetails(wt *models.WorktreeInfo) (string, string, map[string]bool, map[string]bool) {
+func (m *Model) getCachedDetails(wt *models.WorktreeInfo, allowRevalidate bool) (string, string, map[string]bool, map[string]bool) {
 	if wt == nil || strings.TrimSpace(wt.Path) == "" {
 		return "", "", nil, nil
 	}
 
 	cacheKey := wt.Path
-	if cached, ok := m.getDetailsCache(cacheKey); ok {
-		if time.Since(cached.fetchedAt) < detailsCacheTTL {
-			return cached.statusRaw, cached.logRaw, cached.unpushedSHAs, cached.unmergedSHAs
+	cached, haveCached := m.getDetailsCache(cacheKey)
+	if haveCached && time.Since(cached.fetchedAt) < detailsCacheTTL {
+		return cached.statusRaw, cached.logRaw, cached.unpushedSHAs, cached.unmergedSHAs
+	}
+
+	// With the git watcher active, ref/log changes arrive as watcher events
+	// that drop this cache entry. An entry that merely expired can therefore
+	// be revalidated with two cheap commands (status + HEAD) instead of the
+	// full fetch, sparing the log and rev-list subprocesses on idle ticks.
+	if haveCached && allowRevalidate {
+		var statusRaw, headSHA string
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			statusRaw = m.state.services.git.RunGit(m.ctx, []string{"git", "status", "--porcelain=v2"}, wt.Path, []int{0}, true, false)
+		}()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			headSHA = strings.TrimSpace(m.state.services.git.RunGit(m.ctx, []string{"git", "rev-parse", "HEAD"}, wt.Path, []int{0}, true, false))
+		}()
+		wg.Wait()
+		if statusRaw == cached.statusRaw && headSHA != "" && headSHA == cached.headSHA {
+			refreshed := *cached
+			refreshed.fetchedAt = time.Now()
+			m.setDetailsCache(cacheKey, &refreshed)
+			return refreshed.statusRaw, refreshed.logRaw, refreshed.unpushedSHAs, refreshed.unmergedSHAs
 		}
 	}
 
 	mainBranch := m.state.services.git.GetMainBranch(m.ctx)
 
-	var statusRaw, logRaw, unpushedRaw, unmergedRaw string
+	var statusRaw, logRaw, headSHA, unpushedRaw, unmergedRaw string
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
@@ -403,6 +428,11 @@ func (m *Model) getCachedDetails(wt *models.WorktreeInfo) (string, string, map[s
 		defer wg.Done()
 		// Use %H for full SHA to ensure reliable matching
 		logRaw = m.state.services.git.RunGit(m.ctx, []string{"git", "log", "-50", "--pretty=format:%H%x09%an%x09%s"}, wt.Path, []int{0}, true, false)
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		headSHA = strings.TrimSpace(m.state.services.git.RunGit(m.ctx, []string{"git", "rev-parse", "HEAD"}, wt.Path, []int{0}, true, false))
 	}()
 	wg.Add(1)
 	go func() {
@@ -439,6 +469,7 @@ func (m *Model) getCachedDetails(wt *models.WorktreeInfo) (string, string, map[s
 	m.setDetailsCache(cacheKey, &detailsCacheEntry{
 		statusRaw:    statusRaw,
 		logRaw:       logRaw,
+		headSHA:      headSHA,
 		unpushedSHAs: unpushedSHAs,
 		unmergedSHAs: unmergedSHAs,
 		fetchedAt:    time.Now(),

--- a/internal/app/app_status_test.go
+++ b/internal/app/app_status_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/chmouel/lazyworktree/internal/config"
 	"github.com/chmouel/lazyworktree/internal/models"
@@ -186,7 +187,7 @@ func TestGetCachedDetailsCachesResults(t *testing.T) {
 		}
 	})
 
-	statusRaw, logRaw, unpushedSHAs, unmergedSHAs := m.getCachedDetails(wt)
+	statusRaw, logRaw, unpushedSHAs, unmergedSHAs := m.getCachedDetails(wt, false)
 	if statusRaw != "" {
 		t.Fatalf("expected empty status raw, got %q", statusRaw)
 	}
@@ -200,7 +201,7 @@ func TestGetCachedDetailsCachesResults(t *testing.T) {
 		t.Fatalf("expected unmerged SHA to be tracked, got %v", unmergedSHAs)
 	}
 
-	_, _, _, _ = m.getCachedDetails(wt)
+	_, _, _, _ = m.getCachedDetails(wt, false)
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -453,4 +454,113 @@ func TestRestyleLogRowsAuthorColor(t *testing.T) {
 	// Now row 0 should have colour restored, row 1 should be plain
 	assert.Contains(t, rows[0][1], "\x1b[", "previous cursor row should regain author colour")
 	assert.NotContains(t, rows[1][1], "\x1b[", "new cursor row should be plain")
+}
+
+func newDetailsRunnerModel(t *testing.T, headSHA string) (*Model, map[string]int, *sync.Mutex) {
+	t.Helper()
+	cfg := &config.AppConfig{WorktreeDir: t.TempDir()}
+	m := NewModel(cfg, "")
+
+	var mu sync.Mutex
+	callCounts := map[string]int{}
+	// #nosec G702 -- test helper with fixed command arguments
+	m.state.services.git.SetCommandRunner(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		key := name + " " + strings.Join(args, " ")
+		mu.Lock()
+		callCounts[key]++
+		mu.Unlock()
+
+		switch key {
+		case "git symbolic-ref --short refs/remotes/origin/HEAD":
+			return exec.CommandContext(ctx, "echo", "-n", "origin/main") //nolint:gosec
+		case "git status --porcelain=v2":
+			return exec.CommandContext(ctx, "echo", "-n", "") //nolint:gosec
+		case "git rev-parse HEAD":
+			return exec.CommandContext(ctx, "echo", "-n", headSHA) //nolint:gosec
+		case "git log -50 --pretty=format:%H%x09%an%x09%s":
+			return exec.CommandContext(ctx, "echo", "-n", "abc123\talice\tCommit title") //nolint:gosec
+		default:
+			return exec.CommandContext(ctx, "echo", "-n", "") //nolint:gosec
+		}
+	})
+	return m, callCounts, &mu
+}
+
+func TestGetCachedDetailsRevalidatesStaleEntry(t *testing.T) {
+	m, callCounts, mu := newDetailsRunnerModel(t, "headsha")
+	wt := &models.WorktreeInfo{Path: t.TempDir()}
+
+	m.setDetailsCache(wt.Path, &detailsCacheEntry{
+		statusRaw:    "",
+		logRaw:       "cachedsha\talice\tCached title",
+		headSHA:      "headsha",
+		unpushedSHAs: map[string]bool{"cachedsha": true},
+		fetchedAt:    time.Now().Add(-detailsCacheTTL - time.Second),
+	})
+
+	_, logRaw, unpushed, _ := m.getCachedDetails(wt, true)
+	if logRaw != "cachedsha\talice\tCached title" {
+		t.Fatalf("expected cached log to be reused, got %q", logRaw)
+	}
+	if !unpushed["cachedsha"] {
+		t.Fatalf("expected cached unpushed SHAs to be reused, got %v", unpushed)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if callCounts["git status --porcelain=v2"] != 1 {
+		t.Fatalf("expected one status call, got %d", callCounts["git status --porcelain=v2"])
+	}
+	if callCounts["git rev-parse HEAD"] != 1 {
+		t.Fatalf("expected one rev-parse call, got %d", callCounts["git rev-parse HEAD"])
+	}
+	if callCounts["git log -50 --pretty=format:%H%x09%an%x09%s"] != 0 {
+		t.Fatalf("expected log fetch to be skipped, got %d", callCounts["git log -50 --pretty=format:%H%x09%an%x09%s"])
+	}
+	if callCounts["git rev-list -100 HEAD --not --remotes"] != 0 {
+		t.Fatalf("expected rev-list fetch to be skipped, got %d", callCounts["git rev-list -100 HEAD --not --remotes"])
+	}
+}
+
+func TestGetCachedDetailsRevalidationMismatchRefetches(t *testing.T) {
+	m, callCounts, mu := newDetailsRunnerModel(t, "newhead")
+	wt := &models.WorktreeInfo{Path: t.TempDir()}
+
+	m.setDetailsCache(wt.Path, &detailsCacheEntry{
+		statusRaw: "",
+		logRaw:    "cachedsha\talice\tCached title",
+		headSHA:   "oldhead",
+		fetchedAt: time.Now().Add(-detailsCacheTTL - time.Second),
+	})
+
+	_, logRaw, _, _ := m.getCachedDetails(wt, true)
+	if logRaw != "abc123\talice\tCommit title" {
+		t.Fatalf("expected fresh log after HEAD change, got %q", logRaw)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if callCounts["git log -50 --pretty=format:%H%x09%an%x09%s"] != 1 {
+		t.Fatalf("expected full refetch after mismatch, got %d log calls", callCounts["git log -50 --pretty=format:%H%x09%an%x09%s"])
+	}
+}
+
+func TestGetCachedDetailsSkipsRevalidationWithoutWatcher(t *testing.T) {
+	m, callCounts, mu := newDetailsRunnerModel(t, "headsha")
+	wt := &models.WorktreeInfo{Path: t.TempDir()}
+
+	m.setDetailsCache(wt.Path, &detailsCacheEntry{
+		statusRaw: "",
+		logRaw:    "cachedsha\talice\tCached title",
+		headSHA:   "headsha",
+		fetchedAt: time.Now().Add(-detailsCacheTTL - time.Second),
+	})
+
+	_, _, _, _ = m.getCachedDetails(wt, false)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if callCounts["git log -50 --pretty=format:%H%x09%an%x09%s"] != 1 {
+		t.Fatalf("expected full refetch without watcher, got %d log calls", callCounts["git log -50 --pretty=format:%H%x09%an%x09%s"])
+	}
 }

--- a/internal/app/auto_refresh.go
+++ b/internal/app/auto_refresh.go
@@ -52,8 +52,13 @@ func (m *Model) refreshDetails() tea.Cmd {
 	if idx < 0 || idx >= len(m.state.data.filteredWts) {
 		return nil
 	}
-	m.deleteDetailsCache(m.state.data.filteredWts[idx].Path)
+	// Rely on the cache TTL (and watcher-driven invalidation) rather than
+	// dropping the entry outright, so an idle tick can revalidate cheaply.
 	return m.updateDetailsView()
+}
+
+func (m *Model) gitWatcherActive() bool {
+	return m.state.services.watch != nil && m.state.services.watch.Started
 }
 
 func (m *Model) startGitWatcher() tea.Cmd {

--- a/internal/app/auto_refresh_test.go
+++ b/internal/app/auto_refresh_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	tea "charm.land/bubbletea/v2"
+
 	"github.com/chmouel/lazyworktree/internal/app/services"
 	"github.com/chmouel/lazyworktree/internal/config"
 	"github.com/chmouel/lazyworktree/internal/models"
@@ -74,9 +76,10 @@ func TestRefreshDetails(t *testing.T) {
 		cmd := m.refreshDetails()
 		// Command may or may not be nil depending on updateDetailsView implementation
 		_ = cmd
-		// Cache should be cleared
-		if _, ok := m.getDetailsCache(wtPath); ok {
-			t.Error("expected details cache to be cleared")
+		// Cache entry is retained; freshness is governed by the TTL and
+		// watcher-driven invalidation rather than the periodic tick.
+		if _, ok := m.getDetailsCache(wtPath); !ok {
+			t.Error("expected details cache entry to be retained")
 		}
 	}
 }
@@ -257,5 +260,43 @@ func TestShouldRefreshGitEventDebounce(t *testing.T) {
 	}
 	if !m.state.services.watch.ShouldRefresh(now.Add(services.GitWatchDebounce + time.Millisecond)) {
 		t.Fatal("expected refresh after debounce window")
+	}
+}
+
+func TestAutoRefreshTickSuspendsWhenUnfocused(t *testing.T) {
+	cfg := &config.AppConfig{WorktreeDir: t.TempDir(), AutoRefresh: true, RefreshIntervalSeconds: 10}
+	m := NewModel(cfg, "")
+	m.autoRefreshStarted = true
+	m.state.view.TerminalFocused = false
+
+	_, cmd := m.Update(autoRefreshTickMsg{})
+	if cmd != nil {
+		t.Fatal("expected no command while unfocused")
+	}
+	if m.autoRefreshStarted {
+		t.Fatal("expected tick loop to suspend while unfocused")
+	}
+
+	_, cmd = m.Update(tea.FocusMsg{})
+	if !m.autoRefreshStarted {
+		t.Fatal("expected tick loop to resume on focus")
+	}
+	if cmd == nil {
+		t.Fatal("expected focus to schedule work")
+	}
+}
+
+func TestAutoRefreshTickKeepsRunningWhenFocused(t *testing.T) {
+	cfg := &config.AppConfig{WorktreeDir: t.TempDir(), AutoRefresh: true, RefreshIntervalSeconds: 10}
+	m := NewModel(cfg, "")
+	m.autoRefreshStarted = true
+	m.state.view.TerminalFocused = true
+
+	_, cmd := m.Update(autoRefreshTickMsg{})
+	if cmd == nil {
+		t.Fatal("expected the focused tick to reschedule itself")
+	}
+	if !m.autoRefreshStarted {
+		t.Fatal("expected tick loop to stay running while focused")
 	}
 }

--- a/internal/app/services/agent_processes.go
+++ b/internal/app/services/agent_processes.go
@@ -27,10 +27,11 @@ type AgentProcess struct {
 
 // AgentProcessService snapshots live Claude/pi processes.
 type AgentProcessService struct {
-	mu      sync.RWMutex
-	process []*AgentProcess
-	runCmd  agentProcessRunner
-	logf    func(string, ...any)
+	mu           sync.RWMutex
+	process      []*AgentProcess
+	detailsValid bool
+	runCmd       agentProcessRunner
+	logf         func(string, ...any)
 }
 
 // NewAgentProcessService builds a process service with the default command runner.
@@ -62,9 +63,23 @@ func (s *AgentProcessService) Refresh() ([]*AgentProcess, error) {
 	if err != nil {
 		return nil, err
 	}
+	detailsValid := false
 	if len(processes) > 0 {
-		if err := s.populateProcessDetails(processes); err != nil && s.logf != nil {
-			s.logf("agent processes: detail lookup failed: %v", err)
+		s.mu.RLock()
+		previous := s.process
+		previousValid := s.detailsValid
+		s.mu.RUnlock()
+		// lsof is expensive (especially on macOS); when the process set is
+		// unchanged since the last scan, reuse the cached details instead.
+		// Per-process cwd/open-file changes may lag one refresh interval.
+		if previousValid && reuseAgentProcessDetails(processes, previous) {
+			detailsValid = true
+		} else if err := s.populateProcessDetails(processes); err != nil {
+			if s.logf != nil {
+				s.logf("agent processes: detail lookup failed: %v", err)
+			}
+		} else {
+			detailsValid = true
 		}
 	}
 
@@ -77,8 +92,41 @@ func (s *AgentProcessService) Refresh() ([]*AgentProcess, error) {
 
 	s.mu.Lock()
 	s.process = cloneAgentProcesses(processes)
+	s.detailsValid = detailsValid
 	s.mu.Unlock()
 	return cloneAgentProcesses(processes), nil
+}
+
+// reuseAgentProcessDetails copies cached lsof details onto the fresh snapshot
+// when it describes the exact same set of processes as the previous one.
+// It reports false without modifying anything when the sets differ.
+func reuseAgentProcessDetails(processes, previous []*AgentProcess) bool {
+	if len(processes) != len(previous) {
+		return false
+	}
+	byPID := make(map[int]*AgentProcess, len(previous))
+	for _, prev := range previous {
+		if prev != nil {
+			byPID[prev.PID] = prev
+		}
+	}
+	for _, process := range processes {
+		if process == nil {
+			return false
+		}
+		prev, ok := byPID[process.PID]
+		if !ok || prev.Command != process.Command || prev.Args != process.Args {
+			return false
+		}
+	}
+	for _, process := range processes {
+		prev := byPID[process.PID]
+		process.CWD = prev.CWD
+		if len(prev.OpenFiles) > 0 {
+			process.OpenFiles = append([]string(nil), prev.OpenFiles...)
+		}
+	}
+	return true
 }
 
 // Processes returns the last live-process snapshot.

--- a/internal/app/services/agent_processes_test.go
+++ b/internal/app/services/agent_processes_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -208,4 +209,107 @@ func TestClassifyAgentProcessMatchesShellExecWrapper(t *testing.T) {
 
 func stringsJoin(lines ...string) string {
 	return strings.Join(lines, "\n")
+}
+
+func TestRefreshReusesLSOFDetailsWhenProcessesUnchanged(t *testing.T) {
+	psOut := "101 claude claude --continue"
+	lsofOut := "p101\nfcwd\nn/tmp/worktree"
+	lsofCalls := 0
+	runner := func(name string, args ...string) *exec.Cmd {
+		switch name {
+		case "ps":
+			return exec.Command("printf", "%s", psOut)
+		case "lsof":
+			lsofCalls++
+			return exec.Command("printf", "%s", lsofOut)
+		default:
+			return exec.Command("true")
+		}
+	}
+	s := NewAgentProcessServiceWithRunner(runner, nil)
+
+	first, err := s.Refresh()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(first) != 1 || first[0].CWD != "/tmp/worktree" {
+		t.Fatalf("expected cwd from lsof, got %#v", first)
+	}
+	if lsofCalls != 1 {
+		t.Fatalf("expected 1 lsof call, got %d", lsofCalls)
+	}
+
+	second, err := s.Refresh()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if lsofCalls != 1 {
+		t.Fatalf("expected lsof to be skipped for unchanged processes, got %d calls", lsofCalls)
+	}
+	if len(second) != 1 || second[0].CWD != "/tmp/worktree" {
+		t.Fatalf("expected cached cwd to be reused, got %#v", second)
+	}
+}
+
+func TestRefreshRerunsLSOFWhenProcessSetChanges(t *testing.T) {
+	psOut := "101 claude claude --continue"
+	lsofCalls := 0
+	runner := func(name string, args ...string) *exec.Cmd {
+		switch name {
+		case "ps":
+			return exec.Command("printf", "%s", psOut)
+		case "lsof":
+			lsofCalls++
+			return exec.Command("printf", "%s", "p101\nfcwd\nn/tmp/worktree")
+		default:
+			return exec.Command("true")
+		}
+	}
+	s := NewAgentProcessServiceWithRunner(runner, nil)
+
+	if _, err := s.Refresh(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	psOut = "101 claude claude --continue\n202 pi pi --continue"
+	if _, err := s.Refresh(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if lsofCalls != 2 {
+		t.Fatalf("expected lsof to run again after process set change, got %d calls", lsofCalls)
+	}
+}
+
+func TestRefreshRetriesLSOFAfterFailure(t *testing.T) {
+	lsofFails := true
+	lsofCalls := 0
+	runner := func(name string, args ...string) *exec.Cmd {
+		switch name {
+		case "ps":
+			return exec.Command("printf", "%s", "101 claude claude --continue")
+		case "lsof":
+			lsofCalls++
+			if lsofFails {
+				return exec.Command("false")
+			}
+			return exec.Command("printf", "%s", "p101\nfcwd\nn/tmp/worktree")
+		default:
+			return exec.Command("true")
+		}
+	}
+	s := NewAgentProcessServiceWithRunner(runner, nil)
+
+	if _, err := s.Refresh(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	lsofFails = false
+	processes, err := s.Refresh()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if lsofCalls != 2 {
+		t.Fatalf("expected lsof retry after failure, got %d calls", lsofCalls)
+	}
+	if len(processes) != 1 || processes[0].CWD != "/tmp/worktree" {
+		t.Fatalf("expected cwd after successful retry, got %#v", processes)
+	}
 }


### PR DESCRIPTION
Reduces CPU usage while the TUI sits idle.

## What changed

- **lsof gating**: the agent process scan now skips the expensive `lsof` call when the process set is unchanged since the last refresh, reusing cached cwd/open-file details (with retry after a failed scan).
- **Change-aware details refresh**: when the git watcher is active, an expired details cache entry is revalidated with two cheap commands (`git status` + `git rev-parse HEAD`) instead of the full fetch; watcher events force full refetches.
- **Tick suspension**: the auto-refresh loop suspends entirely while the terminal is unfocused and resumes on focus. Terminals without focus reporting keep the loop running.
- **Snapshot skipping**: identical agent-session refresh results no longer rebuild the pane.
- **Hidden profiling hook**: `LAZYWORKTREE_PPROF=<file>` writes a CPU profile for future investigations.

## Measurements (60s idle, default config)

| Metric | Before | After |
| --- | --- | --- |
| Git subprocesses per 10s tick | 4–5 | 2 |
| Agent scan per tick | ps + lsof | ps only (when unchanged) |
| Periodic work while unfocused | ticks forever | none |

