### PR TITLE
feat: add agent lifecycle hooks

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -2,7 +2,7 @@ name: Weekly
 
 on:
   schedule:
-    - cron: "0 6 * * 1"  # Weekly on Monday at 06:00 UTC
+    - cron: "0 6 * * 1" # Weekly on Monday at 06:00 UTC
   workflow_dispatch:
 
 permissions:
@@ -75,4 +75,4 @@ jobs:
         if: ${{ steps.create-pr.outputs.pull-request-number != '' }}
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: gh pr merge --auto --merge "${{ steps.create-pr.outputs.pull-request-number }}"
+        run: gh pr merge --auto --rebase "${{ steps.create-pr.outputs.pull-request-number }}"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ _[You can see more screenshots here](https://chmouel.github.io/lazyworktree/#scr
 
 - Worktree management - Create worktrees from branches, PRs/MRs, or issues; clean up, delete, list, and switch between them
 - CI & PR/MR status - See GitHub Actions and GitLab CI results, check PR/MR details, view logs and more.
-- Agent sessions pane - See confirmed active Claude and pi sessions attached to the selected worktree.
+- Agent sessions pane - See confirmed active Claude, Codex, Copilot, and pi sessions attached to the selected worktree.
 - Command palette - Quick access to all actions and custom commands with `?`.
 - Tmux and Zellij support - Automatically open worktrees in new tmux windows/panes or zellij tabs
 - Docker/Podman support - Run commands in Docker or Podman containers tied to the worktree

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -6,6 +6,7 @@ This page is generated from `internal/bootstrap/*.go`. Run `make docs-sync` afte
 | Command | Usage | Args | Aliases | Guide |
 | --- | --- | --- | --- | --- |
 | `list` | List all worktrees | `-` | `ls` | [`list`](list.md) |
+| `setup-hooks` | Install agent session hooks for Claude Code, Codex CLI, and Copilot CLI | `-` | - | [`setup-hooks`](setup-hooks.md) |
 | `create` | Create a new worktree | `[worktree-name]` | - | [`create`](create.md) |
 | `delete` | Delete a worktree | `[worktree-path]` | - | [`delete`](delete.md) |
 | `cleanup` | Remove merged worktrees, stale branches, and orphaned directories | `-` | - | [`cleanup`](cleanup.md) |
@@ -27,6 +28,14 @@ List all worktrees
 | `--main`, `-m` | `bool` | Show only the main branch worktree |
 | `--no-agent` | `bool` | Skip agent session data in JSON output (faster for scripting) |
 | `--pristine`, `-p` | `bool` | Output paths only (one per line, suitable for scripting) |
+
+## `setup-hooks`
+
+Install agent session hooks for Claude Code, Codex CLI, and Copilot CLI
+
+| Flag | Type | Usage |
+| --- | --- | --- |
+| `--dry-run` | `bool` | Show the changes without writing any files |
 
 ## `create`
 

--- a/docs/cli/flags.md
+++ b/docs/cli/flags.md
@@ -30,6 +30,12 @@ Run `make docs-sync` after changing flag definitions.
 | `--no-agent` | `bool` | Skip agent session data in JSON output (faster for scripting) |
 | `--pristine`, `-p` | `bool` | Output paths only (one per line, suitable for scripting) |
 
+### `setup-hooks`
+
+| Flag | Type | Usage |
+| --- | --- | --- |
+| `--dry-run` | `bool` | Show the changes without writing any files |
+
 ### `create`
 
 | Flag | Type | Usage |

--- a/docs/cli/setup-hooks.md
+++ b/docs/cli/setup-hooks.md
@@ -1,0 +1,77 @@
+# setup-hooks
+
+Install agent session hooks for Claude Code, the Codex CLI, and the Copilot
+CLI.
+
+## Synopsis
+
+```bash
+lazyworktree setup-hooks
+lazyworktree setup-hooks --dry-run
+```
+
+## What it does
+
+`setup-hooks` adds lifecycle hooks to the user-level configurations of
+supported agents:
+
+- **Claude Code** — `~/.claude/settings.json` (`SessionStart`,
+  `UserPromptSubmit`, `Stop`, `SessionEnd`, and question-dialog lifecycle
+  events)
+- **Codex CLI** — `$CODEX_HOME/hooks.json` when `CODEX_HOME` is set, otherwise
+  `~/.codex/hooks.json` (`SessionStart`, `UserPromptSubmit`, and `Stop`)
+- **Copilot CLI** — `$COPILOT_HOME/hooks/lazyworktree.json` when
+  `COPILOT_HOME` is set, otherwise `~/.copilot/hooks/lazyworktree.json`
+  (`SessionStart`, `UserPromptSubmit`, `Stop`, `SessionEnd`, and
+  question-dialog lifecycle events)
+
+Each hook invokes the hidden `lazyworktree agent-event` shim, which records a
+small event file that the TUI consumes on its next refresh. Hook events give
+lazyworktree precise session state — including the agent process id — so it
+can track liveness with a cheap PID probe instead of scanning the process
+table, and it enables Codex CLI and Copilot CLI sessions to appear in the
+agents pane at all (neither exposes a stable transcript format, so
+lazyworktree does not parse them). For Claude Code and Copilot CLI, the
+question-dialog events also distinguish an agent waiting for your answer from
+one that is still thinking. Codex CLI does not currently expose an equivalent
+question-dialog hook.
+
+Hook events are the default liveness source: the former process-table scan
+(ps/lsof) is deprecated and disabled by default. If you cannot install hooks,
+re-enable it with `agent_sessions.process_scan: true` in the
+[configuration](../configuration/reference.md).
+
+## Safety
+
+- Existing settings are preserved; only the lazyworktree hook entries are
+  merged in.
+- A timestamped backup (for example `settings.json.bak-20260712-203500`) is
+  written before any modification.
+- The command is idempotent: running it again reports that the hooks are
+  already installed and changes nothing.
+- The hook shim always exits successfully, so a broken spool can never
+  disrupt an agent session.
+
+## Agent-specific notes
+
+- **Codex CLI** requires newly installed hooks to be approved before they
+  run. After installing, open a Codex session and run the `/hooks` command to
+  trust the new entries.
+- **Copilot CLI** loads hook files at startup. Restart any running `copilot`
+  session after installing.
+
+## Options
+
+| Flag | Description |
+| ---- | ----------- |
+| `--dry-run` | Show the configuration changes without writing any files. |
+
+## Examples
+
+```bash
+# Preview the changes first
+lazyworktree setup-hooks --dry-run
+
+# Install the hooks
+lazyworktree setup-hooks
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -156,11 +156,12 @@ git config --local --get-regexp "^lw\."
 
 ### Agent sessions
 
-The Agent Sessions pane surfaces live AI coding-agent transcripts (Claude Code, pi) per worktree. Settings are grouped under `agent_sessions`:
+The Agent Sessions pane surfaces live Claude Code, Codex CLI, Copilot CLI, and pi sessions per worktree. Settings are grouped under `agent_sessions`:
 
 - `disabled`: set to `true` to turn off transcript watching entirely and hide the pane (default: `false`).
 - `refresh_debounce_ms`: debounce window in milliseconds for transcript-driven refreshes (default: `600`). Raise it to lower CPU while an agent is actively writing; set to `0` to disable throttling.
 - `claude_root`, `pi_root`: override the base directories searched for transcripts (defaults: `~/.claude/projects` and `~/.pi/agent/sessions`).
+- `process_scan` (deprecated): set to `true` to re-enable the ps/lsof process-table scan for session liveness (default: `false`). Prefer `lazyworktree setup-hooks`, which provides precise hook-based tracking instead.
 
 ```yaml
 agent_sessions:
@@ -168,6 +169,7 @@ agent_sessions:
   refresh_debounce_ms: 600
   claude_root: ~/.claude/projects
   pi_root: ~/.pi/agent/sessions
+  process_scan: false
 ```
 
 See [AI integration](guides/ai-integration.md) for transcript discovery details.

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -51,7 +51,7 @@ This page is generated from `internal/config/config.go`. Run `make docs-sync` af
 | `custom_create_menus` | `[]object` | `none` | Custom create menu entries. |
 | `custom_themes` | `map[string]object` | `none` | Custom theme definitions. |
 | `debug_log` | `string` | `none` | Debug log file path. |
-| `agent_sessions` | `object` | `none` | Agent-session pane settings. Nested options: `claude_root` and `pi_root` (custom transcript base directories); `disabled` (`bool`, default `false`) to turn off transcript watching and hide the Agent Sessions pane; `refresh_debounce_ms` (`int`, default `600`) to throttle transcript re-parsing — raise it to lower CPU while an agent is actively writing, set `0` to disable throttling. |
+| `agent_sessions` | `object` | `none` | Agent-session pane settings. Nested options: `claude_root` and `pi_root` (custom transcript base directories); `disabled` (`bool`, default `false`) to turn off transcript watching and hide the Agent Sessions pane; `refresh_debounce_ms` (`int`, default `600`) to throttle transcript re-parsing — raise it to lower CPU while an agent is actively writing, set `0` to disable throttling; `process_scan` (`bool`, default `false`, deprecated) to re-enable the ps/lsof process-table liveness scan — prefer `lazyworktree setup-hooks` instead. |
 | `layout_sizes` | `object` | `none` | Configurable baseline layout weights for panes (`worktrees`, `info`, `git_status`, `commit`, `agent_sessions`, `notes`). Relative weights are normalised at runtime. |
 | `worktree_note_type` | `enum(onejson\|splitted)` | `onejson` | Note storage format strategy. Use `onejson` (default) for a single shared JSON file, or `splitted` for individual markdown files with YAML frontmatter. |
 <!-- END GENERATED:config-reference -->

--- a/docs/core/navigation-and-keybindings.md
+++ b/docs/core/navigation-and-keybindings.md
@@ -13,7 +13,7 @@ The TUI is organised into six panes:
 | Git Status | `3` | Changed files in the selected worktree (collapsible tree view) |
 | Commit Log | `4` | Commit history for the selected branch |
 | Notes | `5` | Per-worktree notes (visible only when a note exists) |
-| Agent Sessions | `6` | Open Claude and pi sessions attached to the selected worktree by default; historical sessions can be revealed on demand |
+| Agent Sessions | `6` | Open Claude, Codex, Copilot, and pi sessions attached to the selected worktree by default; historical sessions can be revealed on demand |
 
 ![LazyWorktree pane layout](../assets/screenshot-main.png)
 
@@ -51,7 +51,7 @@ Press `=` to toggle zoom for the focused pane, expanding it to fill the entire s
 | `L` | Toggle layout (`default` / `top`) |
 
 Agent Sessions is the final pane in the Tab cycle when visible, even though it is rendered above Notes.
-By default the pane shows only sessions with a live Claude/pi process match; press `A` in the pane to include offline history, and press `6` to reveal historical matches when nothing is currently open.
+By default the pane shows only sessions with confirmed live agent processes; press `A` in the pane to include offline history, and press `6` to reveal historical matches when nothing is currently open.
 
 ## Pane-Specific Actions
 

--- a/docs/guides/ai-integration.md
+++ b/docs/guides/ai-integration.md
@@ -89,10 +89,38 @@ lazyworktree worktrees context my-feature --json | jq '.agent_sessions[] | selec
 | `source` value | Meaning |
 |---|---|
 | `"native"` | Session reported itself as active (e.g. Claude Code's own status) |
+| `"hook"` | An agent lifecycle hook reported the session and its process is alive |
 | `"exact_file"` | Live process has the session transcript file open |
 | `"cwd_heuristic"` | Live process working directory matches the worktree path |
 | `"registry"` | Recovered from the persistent registry after a parse failure |
 | `"none"` | No liveness signal found |
+
+### Precise session tracking with lifecycle hooks
+
+For the most accurate and lowest-cost session tracking, install the agent
+lifecycle hooks:
+
+```bash
+lazyworktree setup-hooks --dry-run   # preview the changes
+lazyworktree setup-hooks             # install
+```
+
+This wires Claude Code (`~/.claude/settings.json`), the Codex CLI
+(`$CODEX_HOME/hooks.json`, or `~/.codex/hooks.json` when `CODEX_HOME` is
+unset), and the Copilot CLI (`$COPILOT_HOME/hooks/lazyworktree.json`, or
+`~/.copilot/hooks/lazyworktree.json` when `COPILOT_HOME` is unset) to report
+session lifecycle events directly to lazyworktree. Hook-tracked sessions
+carry the agent process id, so liveness is confirmed with a cheap PID probe,
+and Codex CLI and Copilot CLI sessions become visible in the agents pane. See
+[setup-hooks](../cli/setup-hooks.md) for details, including the Codex `/hooks`
+approval step. Claude Code and Copilot CLI hooks also report when a question
+dialog opens and when its answer returns, so the pane switches from
+**thinking** to **waiting** while the agent needs your input. Codex CLI does
+not currently expose an equivalent question-dialog hook.
+
+Hooks are the default liveness source. The former process-table scan
+(ps/lsof) is deprecated and disabled by default; set
+`agent_sessions.process_scan: true` in the configuration to opt back in.
 
 ### 5. Use `exec --json` for command automation
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -92,7 +92,7 @@ Press `T` to open Taskboard (Kanban-lite grouped by worktree notes).
 
 ## Agent Sessions Pane
 
-Shows Claude and pi sessions whose working directory is inside the selected worktree. By default it shows only confirmed active sessions, then lets you expand to recent and heuristic matches.
+Shows Claude, Codex, Copilot, and pi sessions whose working directory is inside the selected worktree. By default it shows only confirmed active sessions, then lets you expand to recent and heuristic matches.
 
 | Key | Action |
 | --- | --- |

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/muesli/reflow v0.3.0
 	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli/v3 v3.10.1
+	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -38,5 +39,4 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sync v0.22.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
 )

--- a/hack/docsync/main.go
+++ b/hack/docsync/main.go
@@ -234,7 +234,7 @@ func parseCommands(dir string) ([]commandSpec, error) {
 	allowedFuncs := map[string]struct{}{
 		"createCommand": {}, "deleteCommand": {}, "cleanupCommand": {}, "renameCommand": {}, "listCommand": {},
 		"execCommand": {}, "noteCommand": {}, "describeCommand": {}, "doctorCommand": {},
-		"worktreesCommand": {}, "notesCommand": {},
+		"worktreesCommand": {}, "notesCommand": {}, "setupHooksCommand": {},
 	}
 	for _, file := range files {
 		for _, decl := range file.Decls {
@@ -457,7 +457,7 @@ func parseConfigKeys(path string) ([]configKeySpec, error) {
 		"custom_create_menus":          "Custom create menu entries.",
 		"custom_themes":                "Custom theme definitions.",
 		"worktree_note_type":           "Note storage format strategy. Use `onejson` (default) for a single shared JSON file, or `splitted` for individual markdown files with YAML frontmatter.",
-		"agent_sessions":               "Agent-session pane settings. Nested options: `claude_root` and `pi_root` (custom transcript base directories); `disabled` (`bool`, default `false`) to turn off transcript watching and hide the Agent Sessions pane; `refresh_debounce_ms` (`int`, default `600`) to throttle transcript re-parsing — raise it to lower CPU while an agent is actively writing, set `0` to disable throttling.",
+		"agent_sessions":               "Agent-session pane settings. Nested options: `claude_root` and `pi_root` (custom transcript base directories); `disabled` (`bool`, default `false`) to turn off transcript watching and hide the Agent Sessions pane; `refresh_debounce_ms` (`int`, default `600`) to throttle transcript re-parsing — raise it to lower CPU while an agent is actively writing, set `0` to disable throttling; `process_scan` (`bool`, default `false`, deprecated) to re-enable the ps/lsof process-table liveness scan — prefer `lazyworktree setup-hooks` instead.",
 		"layout_sizes":                 "Configurable baseline layout weights for panes (`worktrees`, `info`, `git_status`, `commit`, `agent_sessions`, `notes`). Relative weights are normalised at runtime.",
 	}
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -331,6 +331,7 @@ type servicesState struct {
 	watch          *services.GitWatchService
 	agentSessions  *services.AgentSessionService
 	agentProcesses *services.AgentProcessService
+	agentHooks     *services.AgentHookService
 	agentWatch     *services.AgentWatchService
 	filter         *services.FilterService
 }
@@ -389,6 +390,9 @@ type Model struct {
 
 	// Auto refresh
 	autoRefreshStarted bool
+
+	// Agent process scanning cadence when hooks provide coverage
+	lastAgentProcessScan time.Time
 
 	// Trust / repo commands
 	repoConfig     *config.RepoConfig
@@ -601,12 +605,21 @@ func NewModel(cfg *config.AppConfig, initialFilter string) *Model {
 	m.state.services.agentSessions = services.NewAgentSessionServiceFromConfig(
 		cfg.AgentSessionClaudeRoot, cfg.AgentSessionPiRoot, m.debugf,
 	)
-	m.state.services.agentProcesses = services.NewAgentProcessService(m.debugf)
-	m.state.services.agentWatch = services.NewAgentWatchService(
-		m.state.services.agentSessions.WatchRoots(),
+	m.state.services.agentHooks = services.NewAgentHookService(services.AgentHookSpoolDir(), m.debugf)
+	m.state.services.agentSessions.SetHookService(m.state.services.agentHooks)
+	// The ps/lsof process scan is deprecated and opt-in; hook events installed
+	// via `lazyworktree setup-hooks` are the default liveness source.
+	if cfg.AgentProcessScan {
+		m.state.services.agentProcesses = services.NewAgentProcessService(m.debugf)
+	}
+	spoolDir := m.state.services.agentHooks.Dir()
+	agentWatch := services.NewAgentWatchService(
+		append(m.state.services.agentSessions.WatchRoots(), spoolDir),
 		time.Duration(cfg.AgentRefreshDebounceMs)*time.Millisecond,
 		m.debugf,
 	)
+	agentWatch.SpoolRoots = []string{spoolDir}
+	m.state.services.agentWatch = agentWatch
 	m.state.services.filter = services.NewFilterService(initialFilter)
 
 	gitService.SetCommandRunner(func(ctx context.Context, name string, args ...string) *exec.Cmd {

--- a/internal/app/app_agents.go
+++ b/internal/app/app_agents.go
@@ -3,6 +3,7 @@ package app
 import (
 	"image/color"
 	"strings"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
@@ -51,6 +52,10 @@ func agentSessionsEqual(a, b []*models.AgentSession) bool {
 	return true
 }
 
+// agentProcessScanInterval is the minimum gap between ps/lsof scans while
+// hook-tracked sessions provide live PID coverage.
+const agentProcessScanInterval = 30 * time.Second
+
 func (m *Model) refreshAgentSessions() tea.Cmd {
 	if !m.agentSessionsEnabled() {
 		return nil
@@ -60,14 +65,28 @@ func (m *Model) refreshAgentSessions() tea.Cmd {
 		return nil
 	}
 	processService := m.state.services.agentProcesses
+	// While hook events cover live sessions, PID probes are enough between
+	// full ps/lsof scans; decide on the UI thread to keep the timestamp safe.
+	skipProcessScan := false
+	if hooks := m.state.services.agentHooks; hooks != nil && processService != nil &&
+		time.Since(m.lastAgentProcessScan) < agentProcessScanInterval && hooks.HasLiveSessions() {
+		skipProcessScan = true
+	}
+	if !skipProcessScan {
+		m.lastAgentProcessScan = time.Now()
+	}
 	return func() tea.Msg {
 		var processes []*services.AgentProcess
 		if processService != nil {
-			snapshot, err := processService.Refresh()
-			if err != nil {
-				m.debugf("agent sessions: process refresh failed: %v", err)
+			if skipProcessScan {
+				processes = processService.Processes()
 			} else {
-				processes = snapshot
+				snapshot, err := processService.Refresh()
+				if err != nil {
+					m.debugf("agent sessions: process refresh failed: %v", err)
+				} else {
+					processes = snapshot
+				}
 			}
 		}
 		sessions, err := service.RefreshWithProcesses(processes)
@@ -78,6 +97,11 @@ func (m *Model) refreshAgentSessions() tea.Cmd {
 func (m *Model) startAgentWatcher() tea.Cmd {
 	if !m.agentSessionsEnabled() {
 		return nil
+	}
+	if hooks := m.state.services.agentHooks; hooks != nil {
+		if err := hooks.EnsureDir(); err != nil {
+			return func() tea.Msg { return errMsg{err: err} }
+		}
 	}
 	watcher := m.state.services.agentWatch
 	if watcher == nil || watcher.Started {
@@ -281,10 +305,14 @@ func (m *Model) renderAgentSessionSeparator(width int) string {
 func (m *Model) renderAgentSessionMarker(session *models.AgentSession) string {
 	letter := "C"
 	fg := m.theme.Accent
-	if session != nil && session.Agent == models.AgentKindPi {
+	switch {
+	case session != nil && session.Agent == models.AgentKindPi:
 		letter = "P"
 		fg = m.theme.Cyan
-	} else if m.config != nil && strings.EqualFold(strings.TrimSpace(m.config.IconSet), "nerd-font-v3") {
+	case session != nil && session.Agent == models.AgentKindCodex:
+		letter = "X"
+		fg = m.theme.SuccessFg
+	case m.config != nil && strings.EqualFold(strings.TrimSpace(m.config.IconSet), "nerd-font-v3"):
 		letter = "✻"
 	}
 	return lipgloss.NewStyle().Foreground(fg).Bold(true).Render(letter)
@@ -296,9 +324,6 @@ func (m *Model) renderAgentSessionRight(session *models.AgentSession) string {
 	}
 	styles := m.agentRenderStyles()
 	parts := []string{m.renderAgentSessionActivityBadge(session)}
-	if badge := m.renderAgentSessionLivenessBadge(session); badge != "" {
-		parts = append(parts, badge)
-	}
 	parts = append(parts, styles.muted.Render(formatRelativeTime(session.LastActivity)))
 	return strings.Join(parts, " ")
 }
@@ -336,41 +361,6 @@ func (m *Model) renderAgentSessionBadge(label string, bg, fg color.Color) string
 	return badgeStyle.Render(strings.ToUpper(label))
 }
 
-func (m *Model) renderAgentSessionLivenessBadge(session *models.AgentSession) string {
-	if session == nil {
-		return ""
-	}
-	label := string(session.LivenessState)
-	if label == "" {
-		return ""
-	}
-	var bg, fg color.Color
-	switch session.LivenessState {
-	case models.AgentSessionLivenessActive:
-		bg = m.theme.SuccessFg
-		fg = m.theme.AccentFg
-		switch session.LivenessSource {
-		case models.AgentSessionLivenessSourceExactFile:
-			label = "exact"
-		case models.AgentSessionLivenessSourceNative:
-			label = "native"
-		}
-	case models.AgentSessionLivenessRecent:
-		bg = m.theme.Cyan
-		fg = m.theme.AccentFg
-	case models.AgentSessionLivenessSuspect:
-		bg = m.theme.WarnFg
-		fg = m.theme.AccentFg
-		if session.LivenessSource == models.AgentSessionLivenessSourceCWDHeuristic {
-			label = "cwd"
-		}
-	default:
-		bg = m.theme.BorderDim
-		fg = m.theme.TextFg
-	}
-	return m.renderAgentSessionBadge(label, bg, fg)
-}
-
 func (m *Model) agentSessionTitle(session *models.AgentSession) string {
 	if session == nil {
 		return ""
@@ -386,6 +376,9 @@ func (m *Model) agentSessionTitle(session *models.AgentSession) string {
 	}
 	if session.Agent == models.AgentKindPi {
 		return "pi session"
+	}
+	if session.Agent == models.AgentKindCodex {
+		return "Codex session"
 	}
 	return "Claude session"
 }

--- a/internal/app/app_agents_test.go
+++ b/internal/app/app_agents_test.go
@@ -201,7 +201,7 @@ func TestRenderAgentSessionCardShowsApprovalBadge(t *testing.T) {
 	}
 }
 
-func TestAgentSessionsForSelectedWorktreeIncludesSuspectByDefault(t *testing.T) {
+func TestAgentSessionsForSelectedWorktreeIncludesSuspectWithoutTechnicalBadge(t *testing.T) {
 	cfg := &config.AppConfig{WorktreeDir: t.TempDir()}
 	m := NewModel(cfg, "")
 
@@ -227,8 +227,11 @@ func TestAgentSessionsForSelectedWorktreeIncludesSuspectByDefault(t *testing.T) 
 	visible := []*models.AgentSession{suspect}
 	content := m.buildAgentSessionsContent(visible)
 	plain := ansi.Strip(content)
-	if !strings.Contains(plain, "CWD") {
-		t.Fatalf("expected suspect session badge to render by default, got %q", plain)
+	if !strings.Contains(plain, "editing internal/app/app_agents.go") {
+		t.Fatalf("expected suspect session to render by default, got %q", plain)
+	}
+	if strings.Contains(plain, "CWD") {
+		t.Fatalf("expected technical liveness source to stay hidden, got %q", plain)
 	}
 }
 

--- a/internal/app/screen/help.go
+++ b/internal/app/screen/help.go
@@ -81,13 +81,14 @@ func NewHelpScreen(maxWidth, maxHeight int, customCommands config.CustomCommands
 - Tab reaches pane 5 before the final agent sessions pane when both are visible
 
 **Agent Sessions Pane (pane 6, visible when sessions exist)**
-- j / k: Move between matching Claude / pi sessions
+- j / k: Move between matching Claude / Codex / Copilot / pi sessions
 - Ctrl+D / Ctrl+U: Half page down / up
 - g / G: Jump to top / bottom
 - A: Toggle between active sessions only and all matching sessions
 - 6: Focus agent sessions pane (or toggle zoom if already focused)
 - When no active session is open, pressing 6 reveals recent and historical matching sessions
 - Tab includes pane 6 at the end of the cycle when visible
+- Run lazyworktree setup-hooks to install Claude Code, Codex CLI, and Copilot CLI lifecycle hooks for precise, low-cost status tracking, including questions awaiting your input
 
 **{{HELP_CI_CHECKS}}Git Status Pane (when focused)**
 - j / k: Navigate files and directories

--- a/internal/app/services/agent_hooks.go
+++ b/internal/app/services/agent_hooks.go
@@ -1,0 +1,420 @@
+package services
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/chmouel/lazyworktree/internal/models"
+)
+
+const (
+	// agentHookMaxPayloadBytes caps the size of a single hook payload read from stdin.
+	agentHookMaxPayloadBytes = 256 * 1024
+	// agentHookStaleAfter prunes hook states with no events for this long.
+	agentHookStaleAfter = 24 * time.Hour
+	// agentHookSpoolFileStaleAfter prunes unconsumed spool files older than this.
+	agentHookSpoolFileStaleAfter = 24 * time.Hour
+)
+
+// AgentHookSpoolDir returns the directory where hook shims spool events.
+func AgentHookSpoolDir() string {
+	if xdgStateHome := os.Getenv("XDG_STATE_HOME"); xdgStateHome != "" {
+		return filepath.Join(xdgStateHome, "lazyworktree", "agent-events")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(".local", "state", "lazyworktree", "agent-events")
+	}
+	return filepath.Join(home, ".local", "state", "lazyworktree", "agent-events")
+}
+
+// ParseAgentHookPayload converts a raw hook stdin payload into a spool event.
+func ParseAgentHookPayload(agent models.AgentKind, data []byte) (models.AgentHookEvent, error) {
+	var payload struct {
+		HookEventName       string `json:"hook_event_name"`
+		SessionID           string `json:"session_id"`
+		SessionIDCamel      string `json:"sessionId"`
+		TranscriptPath      string `json:"transcript_path"`
+		TranscriptPathCamel string `json:"transcriptPath"`
+		CWD                 string `json:"cwd"`
+		Model               string `json:"model"`
+		Source              string `json:"source"`
+		NotificationType    string `json:"notification_type"`
+		NotificationCamel   string `json:"notificationType"`
+		ToolName            string `json:"tool_name"`
+		ToolNameCamel       string `json:"toolName"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return models.AgentHookEvent{}, fmt.Errorf("decode hook payload: %w", err)
+	}
+	sessionID := strings.TrimSpace(firstNonEmpty(payload.SessionID, payload.SessionIDCamel))
+	if sessionID == "" {
+		return models.AgentHookEvent{}, errors.New("hook payload missing session_id")
+	}
+	eventName := normalizeAgentHookEventName(
+		payload.HookEventName,
+		firstNonEmpty(payload.NotificationType, payload.NotificationCamel),
+		firstNonEmpty(payload.ToolName, payload.ToolNameCamel),
+	)
+	return models.AgentHookEvent{
+		SchemaVersion:  models.AgentHookEventSchemaVersion,
+		Agent:          agent,
+		HookEventName:  eventName,
+		SessionID:      sessionID,
+		TranscriptPath: strings.TrimSpace(firstNonEmpty(payload.TranscriptPath, payload.TranscriptPathCamel)),
+		CWD:            strings.TrimSpace(payload.CWD),
+		Model:          strings.TrimSpace(payload.Model),
+		Source:         strings.TrimSpace(payload.Source),
+	}, nil
+}
+
+func normalizeAgentHookEventName(eventName, notificationType, toolName string) string {
+	eventName = strings.TrimSpace(eventName)
+	notificationType = strings.TrimSpace(notificationType)
+	toolName = strings.TrimSpace(toolName)
+	switch eventName {
+	case "PreToolUse":
+		if toolName == "ask_user" || toolName == "AskUserQuestion" {
+			return models.AgentHookWaitingForUser
+		}
+	case "Notification":
+		switch notificationType {
+		case "elicitation_dialog", "agent_needs_input":
+			return models.AgentHookWaitingForUser
+		case "elicitation_complete", "elicitation_response":
+			return models.AgentHookUserPromptSubmit
+		}
+	case "PostToolUse":
+		if toolName == "ask_user" || toolName == "AskUserQuestion" {
+			return models.AgentHookUserPromptSubmit
+		}
+	case "Elicitation":
+		return models.AgentHookWaitingForUser
+	case "ElicitationResult":
+		return models.AgentHookUserPromptSubmit
+	}
+	return eventName
+}
+
+type agentHookProcessInfo struct {
+	ParentPID int
+	Command   string
+	Args      string
+}
+
+type agentHookProcessLookup func(pid int) (agentHookProcessInfo, bool)
+
+func agentHookProcessArgs(pid int, command string, resolve func(int) string) string {
+	base := strings.TrimSuffix(strings.ToLower(filepath.Base(strings.TrimSpace(command))), ".exe")
+	if base == "node" || base == "bun" {
+		if args := strings.TrimSpace(resolve(pid)); args != "" {
+			return args
+		}
+	}
+	return filepath.Base(command)
+}
+
+func findAgentAncestorPID(agent models.AgentKind, startPID int, lookup agentHookProcessLookup) int {
+	pid := startPID
+	for range 32 {
+		if pid <= 1 {
+			return 0
+		}
+		process, ok := lookup(pid)
+		if !ok {
+			return 0
+		}
+		kind, _, matched := classifyAgentProcess(process.Command, process.Args)
+		if matched && kind == agent {
+			return pid
+		}
+		if process.ParentPID <= 1 || process.ParentPID == pid {
+			return 0
+		}
+		pid = process.ParentPID
+	}
+	return 0
+}
+
+// RecordAgentHookEvent reads a hook payload from r and spools it into dir.
+// Hook commands run through an intermediate shell, so resolve the matching
+// agent ancestor rather than recording the shell PID.
+func RecordAgentHookEvent(dir string, agent models.AgentKind, r io.Reader) error {
+	data, err := io.ReadAll(io.LimitReader(r, agentHookMaxPayloadBytes))
+	if err != nil {
+		return fmt.Errorf("read hook payload: %w", err)
+	}
+	event, err := ParseAgentHookPayload(agent, data)
+	if err != nil {
+		return err
+	}
+	event.PID = agentHookProcessPID(agent)
+	event.Timestamp = time.Now()
+	return WriteAgentHookEvent(dir, event)
+}
+
+// WriteAgentHookEvent atomically writes one event into the spool directory.
+func WriteAgentHookEvent(dir string, event models.AgentHookEvent) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create spool dir: %w", err)
+	}
+	data, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("encode hook event: %w", err)
+	}
+	name := fmt.Sprintf("%020d-%s-%s.json", event.Timestamp.UnixNano(), event.Agent, sanitizeHookFileComponent(event.HookEventName))
+	return writeAtomically(filepath.Join(dir, name), data)
+}
+
+func sanitizeHookFileComponent(s string) string {
+	if s == "" {
+		return "event"
+	}
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
+			return r
+		default:
+			return '_'
+		}
+	}, s)
+}
+
+// AgentHookState is the accumulated view of one hook-reported session.
+type AgentHookState struct {
+	Agent          models.AgentKind
+	SessionID      string
+	TranscriptPath string
+	CWD            string
+	Model          string
+	Source         string
+	PID            int
+	LastEventName  string
+	LastEventAt    time.Time
+	Ended          bool
+}
+
+// AgentHookService drains spooled hook events and tracks per-session state.
+type AgentHookService struct {
+	mu       sync.Mutex
+	dir      string
+	states   map[string]*AgentHookState
+	pidAlive func(pid int) bool
+	logf     func(format string, args ...any)
+}
+
+// NewAgentHookService creates a hook service reading events from dir.
+func NewAgentHookService(dir string, logf func(format string, args ...any)) *AgentHookService {
+	if logf == nil {
+		logf = func(string, ...any) {}
+	}
+	return &AgentHookService{
+		dir:      dir,
+		states:   map[string]*AgentHookState{},
+		pidAlive: agentHookPIDAlive,
+		logf:     logf,
+	}
+}
+
+// Dir returns the spool directory this service consumes.
+func (s *AgentHookService) Dir() string {
+	return s.dir
+}
+
+// EnsureDir creates the hook spool before the watcher starts so the first
+// event is observable even when the directory did not previously exist.
+func (s *AgentHookService) EnsureDir() error {
+	if err := os.MkdirAll(s.dir, 0o700); err != nil {
+		return fmt.Errorf("create spool dir: %w", err)
+	}
+	if err := os.Chmod(s.dir, 0o700); err != nil { //nolint:gosec // The spool is a directory and needs owner traversal.
+		return fmt.Errorf("secure spool dir: %w", err)
+	}
+	return nil
+}
+
+// Drain consumes all pending spool files and folds them into session states.
+func (s *AgentHookService) Drain() {
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			s.logf("agent hooks: read spool dir: %v", err)
+		}
+		return
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		names = append(names, entry.Name())
+	}
+	sort.Strings(names)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, name := range names {
+		path := filepath.Join(s.dir, name)
+		data, err := os.ReadFile(path) //nolint:gosec // Spool path is app-controlled.
+		if err != nil {
+			s.logf("agent hooks: read %s: %v", name, err)
+			continue
+		}
+		var event models.AgentHookEvent
+		if err := json.Unmarshal(data, &event); err != nil {
+			s.logf("agent hooks: decode %s: %v", name, err)
+			s.removeSpoolFile(path, name)
+			continue
+		}
+		s.applyLocked(event)
+		s.removeSpoolFile(path, name)
+	}
+	s.pruneLocked(time.Now())
+}
+
+func (s *AgentHookService) removeSpoolFile(path, name string) {
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		s.logf("agent hooks: remove %s: %v", name, err)
+		// Avoid re-processing files that cannot be deleted forever.
+		if info, statErr := os.Stat(path); statErr == nil && time.Since(info.ModTime()) > agentHookSpoolFileStaleAfter {
+			s.logf("agent hooks: stale undeletable spool file %s", name)
+		}
+	}
+}
+
+func (s *AgentHookService) applyLocked(event models.AgentHookEvent) {
+	if event.SessionID == "" || event.Agent == "" {
+		return
+	}
+	key := string(event.Agent) + ":" + event.SessionID
+	st, ok := s.states[key]
+	if !ok {
+		st = &AgentHookState{Agent: event.Agent, SessionID: event.SessionID}
+		s.states[key] = st
+	}
+	if event.TranscriptPath != "" {
+		st.TranscriptPath = event.TranscriptPath
+	}
+	if event.CWD != "" {
+		st.CWD = event.CWD
+	}
+	if event.Model != "" {
+		st.Model = event.Model
+	}
+	if event.Source != "" {
+		st.Source = event.Source
+	}
+	if event.PID > 0 {
+		st.PID = event.PID
+	}
+	if !event.Timestamp.IsZero() && event.Timestamp.After(st.LastEventAt) {
+		st.LastEventAt = event.Timestamp
+	}
+	st.LastEventName = event.HookEventName
+	switch event.HookEventName {
+	case models.AgentHookSessionEnd:
+		st.Ended = true
+	case models.AgentHookSessionStart, models.AgentHookUserPromptSubmit, models.AgentHookWaitingForUser,
+		models.AgentHookStop, models.AgentHookCwdChanged:
+		st.Ended = false
+	}
+}
+
+func (s *AgentHookService) pruneLocked(now time.Time) {
+	for key, st := range s.states {
+		if now.Sub(st.LastEventAt) > agentHookStaleAfter {
+			delete(s.states, key)
+			continue
+		}
+		if st.Ended && now.Sub(st.LastEventAt) > agentRecentThreshold {
+			delete(s.states, key)
+		}
+	}
+}
+
+// States returns a snapshot of the current hook-tracked session states.
+func (s *AgentHookService) States() []AgentHookState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]AgentHookState, 0, len(s.states))
+	for _, st := range s.states {
+		out = append(out, *st)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Agent != out[j].Agent {
+			return out[i].Agent < out[j].Agent
+		}
+		return out[i].SessionID < out[j].SessionID
+	})
+	return out
+}
+
+// RestoreSessions rehydrates live hook state from the persisted session
+// registry after a restart. Pending hook events always take precedence.
+func (s *AgentHookService) RestoreSessions(previous map[string]*models.AgentSession) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now()
+	for _, session := range previous {
+		observation := sessionObservationTime(session)
+		if session == nil || session.SchemaVersion != models.AgentHookEventSchemaVersion ||
+			session.LivenessSource != models.AgentSessionLivenessSourceHook ||
+			session.LivenessState != models.AgentSessionLivenessActive || !session.IsOpen ||
+			session.PID <= 0 || strings.TrimSpace(session.ID) == "" || observation.IsZero() ||
+			now.Sub(observation) > agentHookStaleAfter || !s.pidAlive(session.PID) {
+			continue
+		}
+		found := false
+		for _, state := range s.states {
+			if hookStateMatchesSession(state, session) {
+				found = true
+				break
+			}
+		}
+		if found {
+			continue
+		}
+		sessionID := strings.TrimSpace(session.ID)
+		key := string(session.Agent) + ":" + sessionID
+		s.states[key] = &AgentHookState{
+			Agent:          session.Agent,
+			SessionID:      sessionID,
+			TranscriptPath: session.JSONLPath,
+			CWD:            session.CWD,
+			Model:          session.Model,
+			PID:            session.PID,
+			LastEventAt:    observation,
+		}
+	}
+}
+
+// HasLiveSessions reports whether any hook-tracked session still has a live process.
+func (s *AgentHookService) HasLiveSessions() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, st := range s.states {
+		if !st.Ended && st.PID > 0 && s.pidAlive(st.PID) {
+			return true
+		}
+	}
+	return false
+}
+
+// PIDAlive reports whether the given hook-reported PID is still running.
+func (s *AgentHookService) PIDAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	s.mu.Lock()
+	alive := s.pidAlive
+	s.mu.Unlock()
+	return alive(pid)
+}

--- a/internal/app/services/agent_hooks_test.go
+++ b/internal/app/services/agent_hooks_test.go
@@ -1,0 +1,337 @@
+package services
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chmouel/lazyworktree/internal/models"
+)
+
+func TestParseAgentHookPayload(t *testing.T) {
+	event, err := ParseAgentHookPayload(models.AgentKindClaude, []byte(`{
+		"hook_event_name": "SessionStart",
+		"session_id": " abc ",
+		"transcript_path": "/tmp/t.jsonl",
+		"cwd": "/tmp/repo",
+		"model": "opus",
+		"source": "startup"
+	}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event.Agent != models.AgentKindClaude || event.SessionID != "abc" ||
+		event.HookEventName != models.AgentHookSessionStart ||
+		event.TranscriptPath != "/tmp/t.jsonl" || event.CWD != "/tmp/repo" ||
+		event.Model != "opus" || event.Source != "startup" {
+		t.Fatalf("unexpected event: %+v", event)
+	}
+	if event.SchemaVersion != models.AgentHookEventSchemaVersion {
+		t.Fatalf("unexpected schema version: %q", event.SchemaVersion)
+	}
+}
+
+func TestParseAgentHookPayloadErrors(t *testing.T) {
+	if _, err := ParseAgentHookPayload(models.AgentKindClaude, []byte("not json")); err == nil {
+		t.Fatal("expected decode error")
+	}
+	if _, err := ParseAgentHookPayload(models.AgentKindClaude, []byte(`{"hook_event_name":"Stop"}`)); err == nil {
+		t.Fatal("expected missing session_id error")
+	}
+}
+
+func TestRecordAgentHookEventSpoolsFile(t *testing.T) {
+	dir := t.TempDir()
+	payload := strings.NewReader(`{"hook_event_name":"UserPromptSubmit","session_id":"s1","cwd":"/tmp"}`)
+	if err := RecordAgentHookEvent(dir, models.AgentKindCodex, payload); err != nil {
+		t.Fatalf("record failed: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("expected one spool file, got %d (err=%v)", len(entries), err)
+	}
+	name := entries[0].Name()
+	if !strings.HasSuffix(name, "-codex-UserPromptSubmit.json") {
+		t.Fatalf("unexpected spool file name: %q", name)
+	}
+}
+
+func TestFindAgentAncestorPIDSkipsHookShell(t *testing.T) {
+	processes := map[int]agentHookProcessInfo{
+		300: {ParentPID: 200, Command: "lazyworktree", Args: "lazyworktree agent-event --agent codex"},
+		200: {ParentPID: 100, Command: "zsh", Args: "zsh -lc lazyworktree agent-event --agent codex"},
+		100: {ParentPID: 1, Command: "codex", Args: "codex --yolo"},
+	}
+	got := findAgentAncestorPID(models.AgentKindCodex, 300, func(pid int) (agentHookProcessInfo, bool) {
+		process, ok := processes[pid]
+		return process, ok
+	})
+	if got != 100 {
+		t.Fatalf("expected Codex ancestor PID 100, got %d", got)
+	}
+}
+
+func TestAgentHookProcessArgsResolvesWrappedAgent(t *testing.T) {
+	resolvedPID := 0
+	got := agentHookProcessArgs(42, "node.exe", func(pid int) string {
+		resolvedPID = pid
+		return `"C:\Program Files\nodejs\node.exe" C:\Users\me\AppData\Roaming\npm\node_modules\@openai\codex\bin\codex.js`
+	})
+	if resolvedPID != 42 || !strings.Contains(got, `@openai\codex`) {
+		t.Fatalf("wrapped command line was not resolved: pid=%d args=%q", resolvedPID, got)
+	}
+}
+
+func TestAgentHookProcessArgsSkipsNativeAgent(t *testing.T) {
+	called := false
+	got := agentHookProcessArgs(42, "codex.exe", func(int) string {
+		called = true
+		return "unexpected"
+	})
+	if called || got != "codex.exe" {
+		t.Fatalf("native agent should use executable name: called=%v args=%q", called, got)
+	}
+}
+
+func TestAgentHookServiceDrainAppliesEvents(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	write := func(offset time.Duration, event models.AgentHookEvent) {
+		event.SchemaVersion = models.AgentHookEventSchemaVersion
+		event.Timestamp = now.Add(offset)
+		if err := WriteAgentHookEvent(dir, event); err != nil {
+			t.Fatalf("write event: %v", err)
+		}
+	}
+	write(0, models.AgentHookEvent{
+		Agent: models.AgentKindClaude, HookEventName: models.AgentHookSessionStart,
+		SessionID: "s1", TranscriptPath: "/tmp/s1.jsonl", CWD: "/tmp/repo", Model: "opus", PID: 4242,
+	})
+	write(time.Second, models.AgentHookEvent{
+		Agent: models.AgentKindClaude, HookEventName: models.AgentHookUserPromptSubmit,
+		SessionID: "s1", PID: 4242,
+	})
+	write(2*time.Second, models.AgentHookEvent{
+		Agent: models.AgentKindCodex, HookEventName: models.AgentHookSessionStart,
+		SessionID: "c1", CWD: "/tmp/repo", PID: 999,
+	})
+
+	svc := NewAgentHookService(dir, nil)
+	svc.Drain()
+
+	states := svc.States()
+	if len(states) != 2 {
+		t.Fatalf("expected 2 states, got %d: %+v", len(states), states)
+	}
+	claude := states[0]
+	if claude.Agent != models.AgentKindClaude || claude.SessionID != "s1" ||
+		claude.TranscriptPath != "/tmp/s1.jsonl" || claude.CWD != "/tmp/repo" ||
+		claude.PID != 4242 || claude.LastEventName != models.AgentHookUserPromptSubmit || claude.Ended {
+		t.Fatalf("unexpected claude state: %+v", claude)
+	}
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 0 {
+		t.Fatalf("expected spool drained, %d files remain", len(entries))
+	}
+}
+
+func TestAgentHookServiceSessionEndMarksEnded(t *testing.T) {
+	dir := t.TempDir()
+	event := models.AgentHookEvent{
+		Agent: models.AgentKindClaude, HookEventName: models.AgentHookSessionEnd,
+		SessionID: "s1", PID: 4242, Timestamp: time.Now(),
+	}
+	if err := WriteAgentHookEvent(dir, event); err != nil {
+		t.Fatalf("write event: %v", err)
+	}
+	svc := NewAgentHookService(dir, nil)
+	svc.Drain()
+	states := svc.States()
+	if len(states) != 1 || !states[0].Ended {
+		t.Fatalf("expected ended state, got %+v", states)
+	}
+}
+
+func TestAgentHookServiceDrainSkipsMalformedFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "bad.json"), []byte("nonsense"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	svc := NewAgentHookService(dir, nil)
+	svc.Drain()
+	if len(svc.States()) != 0 {
+		t.Fatal("expected no states from malformed file")
+	}
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 0 {
+		t.Fatal("expected malformed file removed")
+	}
+}
+
+func TestAgentHookServiceHasLiveSessions(t *testing.T) {
+	svc := NewAgentHookService(t.TempDir(), nil)
+	svc.pidAlive = func(pid int) bool { return pid == 4242 }
+	svc.states["claude:s1"] = &AgentHookState{
+		Agent: models.AgentKindClaude, SessionID: "s1", PID: 4242, LastEventAt: time.Now(),
+	}
+	if !svc.HasLiveSessions() {
+		t.Fatal("expected live session")
+	}
+	svc.states["claude:s1"].Ended = true
+	if svc.HasLiveSessions() {
+		t.Fatal("ended session must not count as live")
+	}
+	svc.states["claude:s1"].Ended = false
+	svc.states["claude:s1"].PID = 1
+	if svc.HasLiveSessions() {
+		t.Fatal("dead PID must not count as live")
+	}
+}
+
+func TestAgentHookServicePruneStale(t *testing.T) {
+	svc := NewAgentHookService(t.TempDir(), nil)
+	svc.states["claude:old"] = &AgentHookState{
+		Agent: models.AgentKindClaude, SessionID: "old",
+		LastEventAt: time.Now().Add(-2 * agentHookStaleAfter),
+	}
+	svc.states["claude:ended"] = &AgentHookState{
+		Agent: models.AgentKindClaude, SessionID: "ended", Ended: true,
+		LastEventAt: time.Now().Add(-2 * agentRecentThreshold),
+	}
+	svc.Drain()
+	if len(svc.States()) != 0 {
+		t.Fatalf("expected stale states pruned, got %+v", svc.States())
+	}
+}
+
+func TestParseAgentHookPayloadCopilot(t *testing.T) {
+	// Copilot CLI VS Code compatible payload (PascalCase event config).
+	event, err := ParseAgentHookPayload(models.AgentKindCopilot, []byte(`{
+		"hook_event_name": "Stop",
+		"session_id": "cop-1",
+		"timestamp": "2026-07-12T20:00:00Z",
+		"cwd": "/tmp/repo",
+		"transcript_path": "/tmp/state/session.jsonl",
+		"stop_reason": "end_turn"
+	}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event.Agent != models.AgentKindCopilot || event.SessionID != "cop-1" ||
+		event.HookEventName != models.AgentHookStop ||
+		event.TranscriptPath != "/tmp/state/session.jsonl" || event.CWD != "/tmp/repo" {
+		t.Fatalf("unexpected event: %+v", event)
+	}
+	if event.Model != "" {
+		t.Fatalf("copilot payloads carry no model, got %q", event.Model)
+	}
+}
+
+func TestParseAgentHookPayloadQuestionLifecycle(t *testing.T) {
+	tests := []struct {
+		name  string
+		agent models.AgentKind
+		data  string
+		want  string
+	}{
+		{
+			name:  "copilot camelCase elicitation",
+			agent: models.AgentKindCopilot,
+			data: `{
+				"hook_event_name": "Notification",
+				"sessionId": "cop-1",
+				"notification_type": "elicitation_dialog",
+				"cwd": "/tmp/repo"
+			}`,
+			want: models.AgentHookWaitingForUser,
+		},
+		{
+			name:  "copilot ask_user opened",
+			agent: models.AgentKindCopilot,
+			data: `{
+				"hook_event_name": "PreToolUse",
+				"session_id": "cop-1",
+				"tool_name": "AskUserQuestion"
+			}`,
+			want: models.AgentHookWaitingForUser,
+		},
+		{
+			name:  "claude snake_case elicitation",
+			agent: models.AgentKindClaude,
+			data: `{
+				"hook_event_name": "Notification",
+				"session_id": "claude-1",
+				"notification_type": "agent_needs_input",
+				"cwd": "/tmp/repo"
+			}`,
+			want: models.AgentHookWaitingForUser,
+		},
+		{
+			name:  "claude elicitation response",
+			agent: models.AgentKindClaude,
+			data: `{
+				"hook_event_name": "Notification",
+				"session_id": "claude-1",
+				"notification_type": "elicitation_response"
+			}`,
+			want: models.AgentHookUserPromptSubmit,
+		},
+		{
+			name:  "claude MCP elicitation",
+			agent: models.AgentKindClaude,
+			data: `{
+				"hook_event_name": "Elicitation",
+				"session_id": "claude-1"
+			}`,
+			want: models.AgentHookWaitingForUser,
+		},
+		{
+			name:  "claude MCP elicitation result",
+			agent: models.AgentKindClaude,
+			data: `{
+				"hook_event_name": "ElicitationResult",
+				"session_id": "claude-1"
+			}`,
+			want: models.AgentHookUserPromptSubmit,
+		},
+		{
+			name:  "copilot ask_user completed",
+			agent: models.AgentKindCopilot,
+			data: `{
+				"hook_event_name": "PostToolUse",
+				"session_id": "cop-1",
+				"tool_name": "AskUserQuestion"
+			}`,
+			want: models.AgentHookUserPromptSubmit,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event, err := ParseAgentHookPayload(tt.agent, []byte(tt.data))
+			if err != nil {
+				t.Fatalf("parse payload: %v", err)
+			}
+			if event.HookEventName != tt.want {
+				t.Fatalf("event name = %q, want %q", event.HookEventName, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindAgentAncestorPIDCopilot(t *testing.T) {
+	processes := map[int]agentHookProcessInfo{
+		300: {ParentPID: 200, Command: "lazyworktree", Args: "lazyworktree agent-event --agent copilot"},
+		200: {ParentPID: 100, Command: "bash", Args: "bash -c lazyworktree agent-event --agent copilot"},
+		100: {ParentPID: 1, Command: "node", Args: "node /usr/lib/node_modules/@github/copilot/index.js"},
+	}
+	got := findAgentAncestorPID(models.AgentKindCopilot, 300, func(pid int) (agentHookProcessInfo, bool) {
+		process, ok := processes[pid]
+		return process, ok
+	})
+	if got != 100 {
+		t.Fatalf("expected Copilot ancestor PID 100, got %d", got)
+	}
+}

--- a/internal/app/services/agent_hooks_unix.go
+++ b/internal/app/services/agent_hooks_unix.go
@@ -1,0 +1,45 @@
+//go:build !windows
+
+package services
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/chmouel/lazyworktree/internal/models"
+)
+
+func agentHookProcessPID(agent models.AgentKind) int {
+	return findAgentAncestorPID(agent, os.Getppid(), func(pid int) (agentHookProcessInfo, bool) {
+		out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "ppid=,comm=,args=").Output() //nolint:gosec // PID is an integer read from the OS process tree.
+		if err != nil {
+			return agentHookProcessInfo{}, false
+		}
+		fields := strings.Fields(string(out))
+		if len(fields) < 2 {
+			return agentHookProcessInfo{}, false
+		}
+		parentPID, err := strconv.Atoi(fields[0])
+		if err != nil {
+			return agentHookProcessInfo{}, false
+		}
+		args := ""
+		if len(fields) > 2 {
+			args = strings.Join(fields[2:], " ")
+		}
+		return agentHookProcessInfo{ParentPID: parentPID, Command: fields[1], Args: args}, true
+	})
+}
+
+// agentHookPIDAlive reports whether a process with the given PID exists.
+func agentHookPIDAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
+}

--- a/internal/app/services/agent_hooks_windows.go
+++ b/internal/app/services/agent_hooks_windows.go
@@ -1,0 +1,77 @@
+//go:build windows
+
+package services
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+	"unsafe"
+
+	"github.com/chmouel/lazyworktree/internal/models"
+	"golang.org/x/sys/windows"
+)
+
+func agentHookProcessPID(agent models.AgentKind) int {
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
+	if err != nil {
+		return 0
+	}
+	defer windows.CloseHandle(snapshot)
+
+	processes := map[int]agentHookProcessInfo{}
+	var entry windows.ProcessEntry32
+	entry.Size = uint32(unsafe.Sizeof(entry))
+	if err := windows.Process32First(snapshot, &entry); err != nil {
+		return 0
+	}
+	for {
+		command := windows.UTF16ToString(entry.ExeFile[:])
+		processes[int(entry.ProcessID)] = agentHookProcessInfo{
+			ParentPID: int(entry.ParentProcessID),
+			Command:   command,
+			Args:      filepath.Base(command),
+		}
+		if err := windows.Process32Next(snapshot, &entry); err != nil {
+			break
+		}
+	}
+
+	return findAgentAncestorPID(agent, os.Getppid(), func(pid int) (agentHookProcessInfo, bool) {
+		process, ok := processes[pid]
+		if !ok {
+			return agentHookProcessInfo{}, false
+		}
+		process.Args = agentHookProcessArgs(pid, process.Command, windowsProcessCommandLine)
+		return process, true
+	})
+}
+
+func windowsProcessCommandLine(pid int) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	filter := "ProcessId = " + strconv.Itoa(pid)
+	out, err := exec.CommandContext(ctx, "powershell.exe", "-NoProfile", "-NonInteractive", "-Command",
+		"(Get-CimInstance -ClassName Win32_Process -Filter '"+filter+"').CommandLine").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// agentHookPIDAlive reports whether the hook-reported process still exists.
+func agentHookPIDAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return err == windows.ERROR_ACCESS_DENIED
+	}
+	_ = windows.CloseHandle(handle)
+	return true
+}

--- a/internal/app/services/agent_processes.go
+++ b/internal/app/services/agent_processes.go
@@ -14,7 +14,7 @@ import (
 
 type agentProcessRunner func(name string, args ...string) *exec.Cmd
 
-// AgentProcess describes a live Claude or pi process that may map to a session.
+// AgentProcess describes a live agent process that may map to a session.
 type AgentProcess struct {
 	PID       int
 	Agent     models.AgentKind
@@ -25,7 +25,10 @@ type AgentProcess struct {
 	OpenFiles []string
 }
 
-// AgentProcessService snapshots live Claude/pi processes.
+// AgentProcessService snapshots live agent CLI processes (Claude, Codex,
+// Copilot, and pi). The ps/lsof process scan is deprecated and opt-in via
+// the agent_sessions.process_scan configuration key; hook events installed
+// with `lazyworktree setup-hooks` are the default liveness source.
 type AgentProcessService struct {
 	mu           sync.RWMutex
 	process      []*AgentProcess
@@ -50,7 +53,7 @@ func NewAgentProcessServiceWithRunner(runCmd agentProcessRunner, logf func(strin
 	}
 }
 
-// Refresh discovers live Claude and pi processes.
+// Refresh discovers live Claude, Codex, and pi processes.
 func (s *AgentProcessService) Refresh() ([]*AgentProcess, error) {
 	if runtime.GOOS == "windows" {
 		s.mu.Lock()
@@ -194,16 +197,75 @@ func parseAgentProcessesPS(out string) []*AgentProcess {
 
 func classifyAgentProcess(command, args string) (models.AgentKind, string, bool) {
 	base := filepath.Base(strings.TrimSpace(command))
+	if strings.EqualFold(filepath.Ext(base), ".exe") {
+		base = strings.TrimSuffix(base, filepath.Ext(base))
+	}
 	switch {
 	case strings.Contains(args, "Claude.app") || base == "Claude":
 		return models.AgentKindClaude, "desktop", true
 	case isClaudeCLIProcess(base, args):
 		return models.AgentKindClaude, "cli", true
+	case isCodexCLIProcess(base, args):
+		return models.AgentKindCodex, "cli", true
+	case isCopilotCLIProcess(base, args):
+		return models.AgentKindCopilot, "cli", true
 	case strings.EqualFold(base, "pi"):
 		return models.AgentKindPi, "cli", true
 	default:
 		return "", "", false
 	}
+}
+
+func isCodexCLIProcess(commandBase, args string) bool {
+	base := strings.ToLower(filepath.Base(strings.TrimSpace(commandBase)))
+	if base == "codex" {
+		return true
+	}
+
+	tokens := splitCommandTokens(args)
+	switch base {
+	case "node", "bun":
+		for _, token := range tokens {
+			normalized := strings.ReplaceAll(strings.ToLower(token), `\`, "/")
+			if strings.Contains(normalized, "/@openai/codex/") ||
+				strings.EqualFold(filepath.Base(token), "codex") {
+				return true
+			}
+		}
+	case "npm", "npx", "pnpm", "yarn":
+		for _, token := range tokens {
+			if strings.EqualFold(token, "@openai/codex") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isCopilotCLIProcess(commandBase, args string) bool {
+	base := strings.ToLower(filepath.Base(strings.TrimSpace(commandBase)))
+	if base == "copilot" {
+		return true
+	}
+
+	tokens := splitCommandTokens(args)
+	switch base {
+	case "node", "bun":
+		for _, token := range tokens {
+			normalized := strings.ReplaceAll(strings.ToLower(token), `\`, "/")
+			if strings.Contains(normalized, "/@github/copilot/") ||
+				strings.EqualFold(filepath.Base(token), "copilot") {
+				return true
+			}
+		}
+	case "npm", "npx", "pnpm", "yarn":
+		for _, token := range tokens {
+			if strings.EqualFold(token, "@github/copilot") {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func isClaudeCLIProcess(commandBase, args string) bool {

--- a/internal/app/services/agent_processes_test.go
+++ b/internal/app/services/agent_processes_test.go
@@ -21,10 +21,11 @@ func TestParseAgentProcessesPS(t *testing.T) {
 		"505 zsh zsh -lc claude --print",
 		"606 npm npm exec @anthropic-ai/claude-code -- --print",
 		"707 bash bash -lc echo claude",
+		"808 codex codex --yolo",
 	))
 
-	if len(processes) != 6 {
-		t.Fatalf("expected 6 agent processes, got %d", len(processes))
+	if len(processes) != 7 {
+		t.Fatalf("expected 7 agent processes, got %d", len(processes))
 	}
 	if processes[0].Agent != models.AgentKindClaude || processes[0].Source != "cli" {
 		t.Fatalf("expected first process to be Claude CLI, got %#v", processes[0])
@@ -39,6 +40,9 @@ func TestParseAgentProcessesPS(t *testing.T) {
 		if processes[idx].Agent != models.AgentKindClaude || processes[idx].Source != "cli" {
 			t.Fatalf("expected wrapped process %d to be Claude CLI, got %#v", idx, processes[idx])
 		}
+	}
+	if processes[6].Agent != models.AgentKindCodex || processes[6].Source != "cli" {
+		t.Fatalf("expected Codex CLI process, got %#v", processes[6])
 	}
 }
 
@@ -311,5 +315,37 @@ func TestRefreshRetriesLSOFAfterFailure(t *testing.T) {
 	}
 	if len(processes) != 1 || processes[0].CWD != "/tmp/worktree" {
 		t.Fatalf("expected cwd after successful retry, got %#v", processes)
+	}
+}
+
+func TestClassifyAgentProcessCopilot(t *testing.T) {
+	cases := []struct {
+		command string
+		args    string
+		want    bool
+	}{
+		{"copilot", "copilot --banner", true},
+		{"/usr/local/bin/copilot", "copilot", true},
+		{"node", "node /usr/lib/node_modules/@github/copilot/index.js", true},
+		{"node.exe", `node.exe C:\Users\me\AppData\Roaming\npm\node_modules\@github\copilot\index.js`, true},
+		{"npx", "npx @github/copilot", true},
+		{"node", "node /srv/app/server.js", false},
+	}
+	for _, tc := range cases {
+		kind, source, ok := classifyAgentProcess(tc.command, tc.args)
+		if ok != tc.want {
+			t.Fatalf("classify(%q, %q) matched=%v, want %v", tc.command, tc.args, ok, tc.want)
+		}
+		if tc.want && (kind != models.AgentKindCopilot || source != "cli") {
+			t.Fatalf("classify(%q, %q) = %v/%v, want copilot/cli", tc.command, tc.args, kind, source)
+		}
+	}
+}
+
+func TestClassifyAgentProcessWindowsCodexWrapper(t *testing.T) {
+	args := `node.exe C:\Users\me\AppData\Roaming\npm\node_modules\@openai\codex\bin\codex.js`
+	kind, source, ok := classifyAgentProcess("node.exe", args)
+	if !ok || kind != models.AgentKindCodex || source != "cli" {
+		t.Fatalf("classify Windows Codex wrapper = %v/%v/%v, want codex/cli/true", kind, source, ok)
 	}
 }

--- a/internal/app/services/agent_registry.go
+++ b/internal/app/services/agent_registry.go
@@ -285,5 +285,11 @@ func deriveAgentSessionTitle(session *models.AgentSession) string {
 	if session.Agent == models.AgentKindPi {
 		return "pi session"
 	}
+	if session.Agent == models.AgentKindCodex {
+		return "Codex session"
+	}
+	if session.Agent == models.AgentKindCopilot {
+		return "Copilot session"
+	}
 	return "Claude session"
 }

--- a/internal/app/services/agent_sessions.go
+++ b/internal/app/services/agent_sessions.go
@@ -75,6 +75,7 @@ type AgentSessionService struct {
 	piRoot     string
 	adapters   []AgentAdapter
 	store      SessionRegistryStore
+	hooks      *AgentHookService
 	logf       func(string, ...any)
 }
 
@@ -167,8 +168,20 @@ func (s *AgentSessionService) RefreshWithProcesses(processes []*AgentProcess) ([
 	}
 
 	s.pruneCache(seen)
-	sessions = s.mergeWithRegistryFallbacks(sessions, previous, seen)
-	sessions = s.classifySessionLiveness(sessions, processes, previous, time.Now())
+	now := time.Now()
+	sessions = s.mergeWithRegistryFallbacks(sessions, previous, seen, now)
+	var hookStates []AgentHookState
+	hooks := s.hookService()
+	if hooks != nil {
+		hooks.Drain()
+		hooks.RestoreSessions(previous)
+		hookStates = hooks.States()
+		sessions = s.applyHookSessions(sessions, hookStates, now)
+	}
+	sessions = s.classifySessionLiveness(sessions, processes, previous, now)
+	if hooks != nil {
+		s.applyHookLiveness(sessions, hooks, hookStates, now)
+	}
 	sort.Slice(sessions, func(i, j int) bool {
 		if agentLivenessRank(sessions[i].LivenessState) != agentLivenessRank(sessions[j].LivenessState) {
 			return agentLivenessRank(sessions[i].LivenessState) > agentLivenessRank(sessions[j].LivenessState)
@@ -1120,6 +1133,7 @@ func (s *AgentSessionService) mergeWithRegistryFallbacks(
 	observed []*models.AgentSession,
 	previous map[string]*models.AgentSession,
 	seen map[string]struct{},
+	now time.Time,
 ) []*models.AgentSession {
 	if len(previous) == 0 {
 		return observed
@@ -1150,14 +1164,25 @@ func (s *AgentSessionService) mergeWithRegistryFallbacks(
 	}
 
 	for _, session := range previous {
-		if session == nil || strings.TrimSpace(session.JSONLPath) == "" {
+		if session == nil {
+			continue
+		}
+		hookBacked := session.SchemaVersion == models.AgentHookEventSchemaVersion
+		if hookBacked {
+			observation := sessionObservationTime(session)
+			if observation.IsZero() || now.Sub(observation) > agentHookStaleAfter {
+				continue
+			}
+		} else if strings.TrimSpace(session.JSONLPath) == "" {
 			continue
 		}
 		cleanPath := filepath.Clean(session.JSONLPath)
-		if _, ok := seen[cleanPath]; !ok {
-			continue
+		if !hookBacked {
+			if _, ok := seen[cleanPath]; !ok {
+				continue
+			}
 		}
-		if _, ok := byPath[cleanPath]; ok {
+		if _, ok := byPath[cleanPath]; ok && cleanPath != "." {
 			continue
 		}
 		fallback := cloneAgentSession(session)

--- a/internal/app/services/agent_sessions_hooks.go
+++ b/internal/app/services/agent_sessions_hooks.go
@@ -1,0 +1,159 @@
+package services
+
+import (
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/chmouel/lazyworktree/internal/models"
+)
+
+// SetHookService attaches a hook spool consumer to the session service.
+func (s *AgentSessionService) SetHookService(hooks *AgentHookService) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.hooks = hooks
+}
+
+func (s *AgentSessionService) hookService() *AgentHookService {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.hooks
+}
+
+// hookStateMatchesSession reports whether a hook state refers to the given session.
+func hookStateMatchesSession(state *AgentHookState, session *models.AgentSession) bool {
+	if session == nil || state == nil || session.Agent != state.Agent {
+		return false
+	}
+	if state.TranscriptPath != "" && session.JSONLPath != "" &&
+		filepath.Clean(state.TranscriptPath) == filepath.Clean(session.JSONLPath) {
+		return true
+	}
+	return state.SessionID != "" && strings.TrimSpace(session.ID) == state.SessionID
+}
+
+// applyHookSessions synthesises sessions for hook-tracked agents that have no
+// transcript-backed session yet (e.g. Codex, whose transcript format is unstable).
+func (s *AgentSessionService) applyHookSessions(sessions []*models.AgentSession, states []AgentHookState, now time.Time) []*models.AgentSession {
+	for i := range states {
+		state := &states[i]
+		if state.Ended {
+			continue
+		}
+		found := false
+		for _, session := range sessions {
+			if hookStateMatchesSession(state, session) {
+				found = true
+				break
+			}
+		}
+		if found {
+			continue
+		}
+		session := &models.AgentSession{
+			Agent:          state.Agent,
+			ID:             state.SessionID,
+			CWD:            state.CWD,
+			JSONLPath:      state.TranscriptPath,
+			Model:          state.Model,
+			PID:            state.PID,
+			Status:         hookEventStatus(state.LastEventName),
+			LastActivity:   state.LastEventAt,
+			LastObservedAt: state.LastEventAt,
+			SchemaVersion:  models.AgentHookEventSchemaVersion,
+		}
+		if session.LastActivity.IsZero() {
+			session.LastActivity = now
+			session.LastObservedAt = now
+		}
+		session.SessionKey = agentSessionKey(session)
+		session.Title = deriveAgentSessionTitle(session)
+		sessions = append(sessions, session)
+	}
+	return sessions
+}
+
+// applyHookLiveness overrides liveness for hook-tracked sessions using PID
+// probes, which are far cheaper and more precise than ps/lsof scans.
+func (s *AgentSessionService) applyHookLiveness(sessions []*models.AgentSession, hooks *AgentHookService, states []AgentHookState, now time.Time) {
+	for i := range states {
+		state := &states[i]
+		for _, session := range sessions {
+			if !hookStateMatchesSession(state, session) {
+				continue
+			}
+			session.PID = state.PID
+			if state.LastEventAt.After(session.LastActivity) {
+				session.LastActivity = state.LastEventAt
+			}
+			if state.LastEventAt.After(session.LastObservedAt) {
+				session.LastObservedAt = state.LastEventAt
+			}
+			if state.CWD != "" {
+				session.CWD = state.CWD
+				session.SessionKey = agentSessionKey(session)
+			}
+			if state.Model != "" && session.Model == "" {
+				session.Model = state.Model
+			}
+			if status := hookEventStatus(state.LastEventName); status != models.AgentSessionStatusUnknown {
+				session.Status = status
+			}
+			alive := !state.Ended && hooks.PIDAlive(state.PID)
+			switch {
+			case alive:
+				session.IsOpen = true
+				session.OpenConfidence = models.AgentOpenConfidenceExact
+				session.LivenessState = models.AgentSessionLivenessActive
+				session.LivenessSource = models.AgentSessionLivenessSourceHook
+				session.LastObservedAt = now
+			case state.Ended && session.LivenessSource != models.AgentSessionLivenessSourceExactFile:
+				// A SessionEnd event is authoritative unless ps proved otherwise.
+				session.IsOpen = false
+				session.OpenConfidence = models.AgentOpenConfidenceNone
+				session.LivenessState = models.AgentSessionLivenessInactive
+				session.LivenessSource = models.AgentSessionLivenessSourceHook
+			}
+			if activity, ok := hookEventActivity(state.LastEventName); ok {
+				session.Activity = activity
+			} else {
+				session.Activity = resolveAgentActivity(
+					session.LastSummaryAt,
+					session.LastToolAt,
+					session.LastToolName,
+					session.CurrentTool,
+					session.IsOpen,
+					session.Status,
+					session.LastActivity,
+					now,
+				)
+			}
+			break
+		}
+	}
+}
+
+func hookEventStatus(eventName string) models.AgentSessionStatus {
+	switch eventName {
+	case models.AgentHookUserPromptSubmit:
+		return models.AgentSessionStatusThinking
+	case models.AgentHookStop, models.AgentHookWaitingForUser:
+		return models.AgentSessionStatusWaitingForUser
+	case models.AgentHookSessionStart, models.AgentHookCwdChanged:
+		return models.AgentSessionStatusIdle
+	default:
+		return models.AgentSessionStatusUnknown
+	}
+}
+
+func hookEventActivity(eventName string) (models.AgentActivity, bool) {
+	switch eventName {
+	case models.AgentHookWaitingForUser, models.AgentHookStop:
+		return models.AgentActivityWaiting, true
+	case models.AgentHookUserPromptSubmit:
+		return models.AgentActivityThinking, true
+	default:
+		return "", false
+	}
+}

--- a/internal/app/services/agent_sessions_hooks_test.go
+++ b/internal/app/services/agent_sessions_hooks_test.go
@@ -1,0 +1,413 @@
+package services
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/chmouel/lazyworktree/internal/models"
+)
+
+func newHookTestServices(t *testing.T) (*AgentSessionService, *AgentHookService) {
+	t.Helper()
+	root := t.TempDir()
+	service := NewAgentSessionServiceWithStore(
+		filepath.Join(root, "claude"), filepath.Join(root, "pi"),
+		NewTestSessionRegistryStore(filepath.Join(root, "registry.json")), nil,
+	)
+	hooks := NewAgentHookService(filepath.Join(root, "spool"), nil)
+	service.SetHookService(hooks)
+	return service, hooks
+}
+
+func TestRefreshSynthesisesCodexSessionFromHooks(t *testing.T) {
+	service, hooks := newHookTestServices(t)
+	hooks.pidAlive = func(pid int) bool { return pid == 999 }
+	event := models.AgentHookEvent{
+		SchemaVersion: models.AgentHookEventSchemaVersion,
+		Agent:         models.AgentKindCodex,
+		HookEventName: models.AgentHookUserPromptSubmit,
+		SessionID:     "c1",
+		CWD:           "/tmp/repo",
+		Model:         "gpt-5",
+		PID:           999,
+		Timestamp:     time.Now(),
+	}
+	if err := WriteAgentHookEvent(hooks.Dir(), event); err != nil {
+		t.Fatalf("write event: %v", err)
+	}
+
+	sessions, err := service.Refresh()
+	if err != nil {
+		t.Fatalf("refresh failed: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 synthesised session, got %d", len(sessions))
+	}
+	session := sessions[0]
+	if session.Agent != models.AgentKindCodex || session.ID != "c1" || session.CWD != "/tmp/repo" {
+		t.Fatalf("unexpected session: %+v", session)
+	}
+	if session.Title != "Codex session" {
+		t.Fatalf("expected Codex title, got %q", session.Title)
+	}
+	if session.LivenessState != models.AgentSessionLivenessActive ||
+		session.LivenessSource != models.AgentSessionLivenessSourceHook ||
+		!session.IsOpen || session.PID != 999 {
+		t.Fatalf("expected hook-live session, got liveness=%s source=%s open=%v pid=%d",
+			session.LivenessState, session.LivenessSource, session.IsOpen, session.PID)
+	}
+	if session.Status != models.AgentSessionStatusThinking {
+		t.Fatalf("expected thinking status, got %s", session.Status)
+	}
+}
+
+func TestRefreshRestoresHookSessionFromRegistry(t *testing.T) {
+	root := t.TempDir()
+	registryPath := filepath.Join(root, "registry.json")
+	newService := func(spool string) (*AgentSessionService, *AgentHookService) {
+		service := NewAgentSessionServiceWithStore(
+			filepath.Join(root, "claude"), filepath.Join(root, "pi"),
+			NewTestSessionRegistryStore(registryPath), nil,
+		)
+		hooks := NewAgentHookService(spool, nil)
+		service.SetHookService(hooks)
+		return service, hooks
+	}
+
+	service, hooks := newService(filepath.Join(root, "spool-1"))
+	hooks.pidAlive = func(pid int) bool { return pid == 999 }
+	event := models.AgentHookEvent{
+		SchemaVersion: models.AgentHookEventSchemaVersion,
+		Agent:         models.AgentKindCodex,
+		HookEventName: models.AgentHookStop,
+		SessionID:     "c1",
+		CWD:           "/tmp/repo",
+		PID:           999,
+		Timestamp:     time.Now(),
+	}
+	if err := WriteAgentHookEvent(hooks.Dir(), event); err != nil {
+		t.Fatalf("write event: %v", err)
+	}
+	if _, err := service.Refresh(); err != nil {
+		t.Fatalf("initial refresh failed: %v", err)
+	}
+
+	restarted, restartedHooks := newService(filepath.Join(root, "spool-2"))
+	restartedHooks.pidAlive = func(pid int) bool { return pid == 999 }
+	sessions, err := restarted.Refresh()
+	if err != nil {
+		t.Fatalf("restart refresh failed: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].Agent != models.AgentKindCodex || sessions[0].ID != "c1" {
+		t.Fatalf("expected restored Codex session, got %+v", sessions)
+	}
+	if sessions[0].Title != "Codex session" {
+		t.Fatalf("expected restored Codex title, got %q", sessions[0].Title)
+	}
+	if sessions[0].LivenessState != models.AgentSessionLivenessActive ||
+		sessions[0].LivenessSource != models.AgentSessionLivenessSourceHook || !sessions[0].IsOpen {
+		t.Fatalf("expected restored Codex session to remain active, got %+v", sessions[0])
+	}
+	if !restartedHooks.HasLiveSessions() {
+		t.Fatal("expected restored hook state to retain live-session tracking")
+	}
+
+	deadRestart, deadHooks := newService(filepath.Join(root, "spool-3"))
+	deadHooks.pidAlive = func(int) bool { return false }
+	deadSessions, err := deadRestart.Refresh()
+	if err != nil || len(deadSessions) != 1 {
+		t.Fatalf("dead-pid restart refresh: sessions=%+v err=%v", deadSessions, err)
+	}
+	if deadSessions[0].LivenessState == models.AgentSessionLivenessActive || deadSessions[0].IsOpen {
+		t.Fatalf("dead persisted PID must not be restored as active: %+v", deadSessions[0])
+	}
+}
+
+func TestRefreshHookSessionUpdatesResumedCWD(t *testing.T) {
+	service, hooks := newHookTestServices(t)
+	hooks.pidAlive = func(pid int) bool { return pid == 999 }
+	oldCWD := filepath.Join(t.TempDir(), "old")
+	newCWD := filepath.Join(t.TempDir(), "new")
+	event := models.AgentHookEvent{
+		SchemaVersion: models.AgentHookEventSchemaVersion,
+		Agent:         models.AgentKindCodex,
+		HookEventName: models.AgentHookSessionStart,
+		SessionID:     "c1",
+		CWD:           oldCWD,
+		PID:           999,
+		Timestamp:     time.Now(),
+	}
+	if err := WriteAgentHookEvent(hooks.Dir(), event); err != nil {
+		t.Fatalf("write initial event: %v", err)
+	}
+	if _, err := service.Refresh(); err != nil {
+		t.Fatalf("initial refresh: %v", err)
+	}
+
+	event.HookEventName = models.AgentHookCwdChanged
+	event.CWD = newCWD
+	event.Timestamp = event.Timestamp.Add(time.Second)
+	if err := WriteAgentHookEvent(hooks.Dir(), event); err != nil {
+		t.Fatalf("write resumed event: %v", err)
+	}
+	sessions, err := service.Refresh()
+	if err != nil || len(sessions) != 1 {
+		t.Fatalf("resumed refresh: sessions=%+v err=%v", sessions, err)
+	}
+	if sessions[0].CWD != newCWD {
+		t.Fatalf("cwd = %q, want latest hook cwd %q", sessions[0].CWD, newCWD)
+	}
+	if sessions[0].SessionKey != agentSessionKey(sessions[0]) {
+		t.Fatalf("session key was not updated after cwd change: %q", sessions[0].SessionKey)
+	}
+}
+
+func TestRefreshHookSessionEndMarksInactive(t *testing.T) {
+	service, hooks := newHookTestServices(t)
+	hooks.pidAlive = func(int) bool { return true }
+	now := time.Now()
+	for i, name := range []string{models.AgentHookSessionStart, models.AgentHookSessionEnd} {
+		event := models.AgentHookEvent{
+			SchemaVersion: models.AgentHookEventSchemaVersion,
+			Agent:         models.AgentKindCodex,
+			HookEventName: name,
+			SessionID:     "c1",
+			CWD:           "/tmp/repo",
+			PID:           999,
+			Timestamp:     now.Add(time.Duration(i) * time.Second),
+		}
+		if err := WriteAgentHookEvent(hooks.Dir(), event); err != nil {
+			t.Fatalf("write event: %v", err)
+		}
+	}
+
+	sessions, err := service.Refresh()
+	if err != nil {
+		t.Fatalf("refresh failed: %v", err)
+	}
+	for _, session := range sessions {
+		if session.Agent != models.AgentKindCodex {
+			continue
+		}
+		if session.LivenessState == models.AgentSessionLivenessActive || session.IsOpen {
+			t.Fatalf("ended session must not be active: %+v", session)
+		}
+	}
+}
+
+func TestRefreshHookPromptReplacesWaitingStatus(t *testing.T) {
+	service, hooks := newHookTestServices(t)
+	hooks.pidAlive = func(pid int) bool { return pid == 999 }
+	stopAt := time.Now().Add(-time.Minute)
+	write := func(name string, timestamp time.Time) {
+		t.Helper()
+		if err := WriteAgentHookEvent(hooks.Dir(), models.AgentHookEvent{
+			SchemaVersion: models.AgentHookEventSchemaVersion,
+			Agent:         models.AgentKindCodex,
+			HookEventName: name,
+			SessionID:     "c1",
+			CWD:           "/tmp/repo",
+			PID:           999,
+			Timestamp:     timestamp,
+		}); err != nil {
+			t.Fatalf("write %s event: %v", name, err)
+		}
+	}
+
+	write(models.AgentHookStop, stopAt)
+	sessions, err := service.Refresh()
+	if err != nil || len(sessions) != 1 {
+		t.Fatalf("refresh stop event: sessions=%+v err=%v", sessions, err)
+	}
+	if sessions[0].Status != models.AgentSessionStatusWaitingForUser {
+		t.Fatalf("expected waiting status, got %s", sessions[0].Status)
+	}
+
+	promptAt := time.Now()
+	write(models.AgentHookUserPromptSubmit, promptAt)
+	sessions, err = service.Refresh()
+	if err != nil || len(sessions) != 1 {
+		t.Fatalf("refresh prompt event: sessions=%+v err=%v", sessions, err)
+	}
+	if sessions[0].Status != models.AgentSessionStatusThinking || sessions[0].Activity != models.AgentActivityThinking {
+		t.Fatalf("expected thinking status/activity, got status=%s activity=%s", sessions[0].Status, sessions[0].Activity)
+	}
+	if sessions[0].LastActivity.Before(promptAt) {
+		t.Fatalf("expected prompt hook to refresh activity time, got %v before %v", sessions[0].LastActivity, promptAt)
+	}
+}
+
+func TestRefreshHookDeadPIDKeepsClassifierVerdict(t *testing.T) {
+	service, hooks := newHookTestServices(t)
+	hooks.pidAlive = func(int) bool { return false }
+	event := models.AgentHookEvent{
+		SchemaVersion: models.AgentHookEventSchemaVersion,
+		Agent:         models.AgentKindCodex,
+		HookEventName: models.AgentHookSessionStart,
+		SessionID:     "c1",
+		CWD:           "/tmp/repo",
+		PID:           999,
+		Timestamp:     time.Now(),
+	}
+	if err := WriteAgentHookEvent(hooks.Dir(), event); err != nil {
+		t.Fatalf("write event: %v", err)
+	}
+
+	sessions, err := service.Refresh()
+	if err != nil {
+		t.Fatalf("refresh failed: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(sessions))
+	}
+	if sessions[0].LivenessState == models.AgentSessionLivenessActive {
+		t.Fatalf("dead PID must not be active: %+v", sessions[0])
+	}
+}
+
+func TestHookStateMatchesSession(t *testing.T) {
+	session := &models.AgentSession{
+		Agent: models.AgentKindClaude, ID: "s1", JSONLPath: "/tmp/a/../t.jsonl",
+	}
+	byPath := AgentHookState{Agent: models.AgentKindClaude, SessionID: "other", TranscriptPath: "/tmp/t.jsonl"}
+	if !hookStateMatchesSession(&byPath, session) {
+		t.Fatal("expected transcript path match")
+	}
+	byID := AgentHookState{Agent: models.AgentKindClaude, SessionID: "s1"}
+	if !hookStateMatchesSession(&byID, session) {
+		t.Fatal("expected session-id match")
+	}
+	wrongAgent := AgentHookState{Agent: models.AgentKindCodex, SessionID: "s1"}
+	if hookStateMatchesSession(&wrongAgent, session) {
+		t.Fatal("agent mismatch must not match")
+	}
+}
+
+func TestRefreshSynthesisesCopilotSessionFromHooks(t *testing.T) {
+	// Refresh() passes no process snapshot, matching the default
+	// configuration where the deprecated ps/lsof scan is disabled: hook
+	// events alone must provide session state and liveness.
+	service, hooks := newHookTestServices(t)
+	hooks.pidAlive = func(pid int) bool { return pid == 424 }
+	event := models.AgentHookEvent{
+		SchemaVersion: models.AgentHookEventSchemaVersion,
+		Agent:         models.AgentKindCopilot,
+		HookEventName: models.AgentHookUserPromptSubmit,
+		SessionID:     "cop-1",
+		CWD:           "/tmp/repo",
+		PID:           424,
+		Timestamp:     time.Now(),
+	}
+	if err := WriteAgentHookEvent(hooks.Dir(), event); err != nil {
+		t.Fatalf("write event: %v", err)
+	}
+
+	sessions, err := service.Refresh()
+	if err != nil {
+		t.Fatalf("refresh failed: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 synthesised session, got %d", len(sessions))
+	}
+	session := sessions[0]
+	if session.Agent != models.AgentKindCopilot || session.ID != "cop-1" {
+		t.Fatalf("unexpected session: %+v", session)
+	}
+	if session.Title != "Copilot session" {
+		t.Fatalf("expected Copilot title, got %q", session.Title)
+	}
+	if session.LivenessState != models.AgentSessionLivenessActive ||
+		session.LivenessSource != models.AgentSessionLivenessSourceHook ||
+		!session.IsOpen || session.PID != 424 {
+		t.Fatalf("expected hook-live session, got liveness=%s source=%s open=%v pid=%d",
+			session.LivenessState, session.LivenessSource, session.IsOpen, session.PID)
+	}
+}
+
+func TestRefreshQuestionLifecycleChangesHookStatus(t *testing.T) {
+	service, hooks := newHookTestServices(t)
+	hooks.pidAlive = func(pid int) bool { return pid == 424 }
+	write := func(name string, timestamp time.Time) {
+		t.Helper()
+		if err := WriteAgentHookEvent(hooks.Dir(), models.AgentHookEvent{
+			SchemaVersion: models.AgentHookEventSchemaVersion,
+			Agent:         models.AgentKindCopilot,
+			HookEventName: name,
+			SessionID:     "cop-1",
+			CWD:           "/tmp/repo",
+			PID:           424,
+			Timestamp:     timestamp,
+		}); err != nil {
+			t.Fatalf("write %s event: %v", name, err)
+		}
+	}
+
+	waitingAt := time.Now()
+	write(models.AgentHookWaitingForUser, waitingAt)
+	sessions, err := service.Refresh()
+	if err != nil || len(sessions) != 1 {
+		t.Fatalf("refresh waiting event: sessions=%+v err=%v", sessions, err)
+	}
+	if sessions[0].Status != models.AgentSessionStatusWaitingForUser {
+		t.Fatalf("status = %s, want waiting", sessions[0].Status)
+	}
+	if sessions[0].Activity != models.AgentActivityWaiting {
+		t.Fatalf("activity = %s, want waiting", sessions[0].Activity)
+	}
+
+	write(models.AgentHookUserPromptSubmit, waitingAt.Add(time.Second))
+	sessions, err = service.Refresh()
+	if err != nil || len(sessions) != 1 {
+		t.Fatalf("refresh response event: sessions=%+v err=%v", sessions, err)
+	}
+	if sessions[0].Status != models.AgentSessionStatusThinking {
+		t.Fatalf("status = %s, want thinking", sessions[0].Status)
+	}
+	if sessions[0].Activity != models.AgentActivityThinking {
+		t.Fatalf("activity = %s, want thinking", sessions[0].Activity)
+	}
+}
+
+func TestHookQuestionActivityOverridesRecentTool(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		event string
+		want  models.AgentActivity
+	}{
+		{event: models.AgentHookWaitingForUser, want: models.AgentActivityWaiting},
+		{event: models.AgentHookUserPromptSubmit, want: models.AgentActivityThinking},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.event, func(t *testing.T) {
+			service := &AgentSessionService{}
+			hooks := NewAgentHookService(t.TempDir(), nil)
+			hooks.pidAlive = func(pid int) bool { return pid == 424 }
+			session := &models.AgentSession{
+				Agent:        models.AgentKindCopilot,
+				ID:           "cop-1",
+				LastToolAt:   now,
+				LastToolName: "Bash",
+				LastActivity: now,
+			}
+			state := AgentHookState{
+				Agent:         models.AgentKindCopilot,
+				SessionID:     "cop-1",
+				PID:           424,
+				LastEventName: tt.event,
+				LastEventAt:   now,
+			}
+
+			service.applyHookLiveness(
+				[]*models.AgentSession{session},
+				hooks,
+				[]AgentHookState{state},
+				now,
+			)
+			if session.Activity != tt.want {
+				t.Fatalf("activity = %s, want %s", session.Activity, tt.want)
+			}
+		})
+	}
+}

--- a/internal/app/services/agent_watch.go
+++ b/internal/app/services/agent_watch.go
@@ -16,11 +16,14 @@ type AgentWatchService struct {
 	Started bool
 	Waiting bool
 	Roots   []string
-	Events  chan struct{}
-	Done    chan struct{}
-	Paths   map[string]struct{}
-	Mu      sync.Mutex
-	Watcher *fsnotify.Watcher
+	// SpoolRoots is the subset of Roots that contain hook spool .json files.
+	// .json events are only accepted from these roots; all roots accept .jsonl.
+	SpoolRoots []string
+	Events     chan struct{}
+	Done       chan struct{}
+	Paths      map[string]struct{}
+	Mu         sync.Mutex
+	Watcher    *fsnotify.Watcher
 	// Debounce throttles how often transcript-write bursts trigger a refresh.
 	// A value <= 0 disables throttling. See PlanRefresh.
 	Debounce    time.Duration
@@ -154,10 +157,11 @@ func (w *AgentWatchService) run() {
 			if event.Op&fsnotify.Create != 0 {
 				w.maybeWatchNewDir(event.Name)
 			}
-			if !strings.HasSuffix(event.Name, ".jsonl") {
-				continue
+			if strings.HasSuffix(event.Name, ".jsonl") {
+				w.signal()
+			} else if strings.HasSuffix(event.Name, ".json") && w.isUnderSpoolRoot(event.Name) {
+				w.signal()
 			}
-			w.signal()
 		case err, ok := <-w.Watcher.Errors:
 			if !ok {
 				return
@@ -226,6 +230,15 @@ func (w *AgentWatchService) signal() {
 
 func (w *AgentWatchService) isUnderRoot(path string) bool {
 	for _, root := range w.Roots {
+		if path == root || strings.HasPrefix(path, root+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}
+
+func (w *AgentWatchService) isUnderSpoolRoot(path string) bool {
+	for _, root := range w.SpoolRoots {
 		if path == root || strings.HasPrefix(path, root+string(filepath.Separator)) {
 			return true
 		}

--- a/internal/app/services/agent_watch_test.go
+++ b/internal/app/services/agent_watch_test.go
@@ -1,9 +1,44 @@
 package services
 
 import (
+	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/chmouel/lazyworktree/internal/models"
 )
+
+func TestAgentWatcherSeesFirstHookEvent(t *testing.T) {
+	spool := filepath.Join(t.TempDir(), "missing", "agent-events")
+	hooks := NewAgentHookService(spool, nil)
+	if err := hooks.EnsureDir(); err != nil {
+		t.Fatalf("ensure spool dir: %v", err)
+	}
+
+	watcher := NewAgentWatchService([]string{spool}, 0, nil)
+	watcher.SpoolRoots = []string{spool}
+	started, err := watcher.Start()
+	if err != nil || !started {
+		t.Fatalf("start watcher: started=%v err=%v", started, err)
+	}
+	t.Cleanup(watcher.Stop)
+	events := watcher.NextEvent()
+
+	if err := WriteAgentHookEvent(spool, models.AgentHookEvent{
+		Agent:         models.AgentKindCodex,
+		HookEventName: models.AgentHookUserPromptSubmit,
+		SessionID:     "first",
+		Timestamp:     time.Now(),
+	}); err != nil {
+		t.Fatalf("write first hook event: %v", err)
+	}
+
+	select {
+	case <-events:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first hook event did not notify watcher")
+	}
+}
 
 func TestAgentWatchPlanRefresh(t *testing.T) {
 	base := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -68,6 +68,8 @@ func Run(args []string) int {
 			execCommand(),
 			noteCommand(),
 			describeCommand(),
+			setupHooksCommand(),
+			agentEventCommand(),
 		},
 
 		Action: func(ctx context.Context, cmd *cli.Command) error {

--- a/internal/bootstrap/commands_agent.go
+++ b/internal/bootstrap/commands_agent.go
@@ -1,0 +1,64 @@
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/chmouel/lazyworktree/internal/app/services"
+	"github.com/chmouel/lazyworktree/internal/commands"
+	"github.com/chmouel/lazyworktree/internal/models"
+	appiCli "github.com/urfave/cli/v3"
+)
+
+// agentEventCommand is the hidden hook shim invoked by Claude Code, Codex
+// CLI, and Copilot CLI lifecycle hooks. It reads the hook payload from stdin
+// and spools a normalised event for the TUI to consume. It always exits
+// successfully so a broken spool never disrupts the agent.
+func agentEventCommand() *appiCli.Command {
+	return &appiCli.Command{
+		Name:   "agent-event",
+		Usage:  "Record an agent lifecycle hook event (internal)",
+		Hidden: true,
+		Flags: []appiCli.Flag{
+			&appiCli.StringFlag{
+				Name:     "agent",
+				Usage:    "Agent kind reporting the event (claude, codex, copilot, pi)",
+				Required: true,
+			},
+		},
+		Action: func(_ context.Context, cmd *appiCli.Command) error {
+			agent := models.AgentKind(cmd.String("agent"))
+			switch agent {
+			case models.AgentKindClaude, models.AgentKindCodex, models.AgentKindCopilot, models.AgentKindPi:
+			default:
+				return nil
+			}
+			if err := services.RecordAgentHookEvent(services.AgentHookSpoolDir(), agent, os.Stdin); err != nil {
+				fmt.Fprintf(os.Stderr, "lazyworktree agent-event: %v\n", err)
+			}
+			return nil
+		},
+	}
+}
+
+// setupHooksCommand installs the agent-event shim into the Claude Code,
+// Codex CLI, and Copilot CLI hook configurations.
+func setupHooksCommand() *appiCli.Command {
+	return &appiCli.Command{
+		Name:  "setup-hooks",
+		Usage: "Install agent session hooks for Claude Code, Codex CLI, and Copilot CLI",
+		Flags: []appiCli.Flag{
+			&appiCli.BoolFlag{
+				Name:  "dry-run",
+				Usage: "Show the changes without writing any files",
+			},
+		},
+		Action: func(_ context.Context, cmd *appiCli.Command) error {
+			return commands.SetupAgentHooks(commands.SetupAgentHooksOptions{
+				DryRun: cmd.Bool("dry-run"),
+				Stdout: os.Stdout,
+			})
+		},
+	}
+}

--- a/internal/commands/agenthooks.go
+++ b/internal/commands/agenthooks.go
@@ -1,0 +1,469 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/google/shlex"
+)
+
+// agentEventShimMarker identifies hook entries installed by lazyworktree.
+const agentEventShimMarker = "lazyworktree agent-event"
+
+type agentHookMatcher struct {
+	Event   string
+	Matcher string
+}
+
+// SetupAgentHooksOptions configures the hook installer.
+type SetupAgentHooksOptions struct {
+	DryRun             bool
+	ClaudeSettingsPath string
+	CodexHooksPath     string
+	CopilotHooksPath   string
+	Stdout             io.Writer
+}
+
+// SetupAgentHooks installs lazyworktree agent-event hooks into the Claude
+// Code, Codex CLI, and Copilot CLI user-level hook configurations. Existing
+// settings are preserved; a timestamped backup is written before any
+// modification.
+func SetupAgentHooks(opts SetupAgentHooksOptions) error {
+	out := opts.Stdout
+	if out == nil {
+		out = os.Stdout
+	}
+	claudePath := opts.ClaudeSettingsPath
+	codexPath := opts.CodexHooksPath
+	copilotPath := opts.CopilotHooksPath
+	if claudePath == "" || codexPath == "" || copilotPath == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("resolve home directory: %w", err)
+		}
+		if claudePath == "" {
+			claudePath = filepath.Join(home, ".claude", "settings.json")
+		}
+		if codexPath == "" {
+			codexHome := strings.TrimSpace(os.Getenv("CODEX_HOME"))
+			if codexHome == "" {
+				codexHome = filepath.Join(home, ".codex")
+			}
+			codexPath = filepath.Join(codexHome, "hooks.json")
+		}
+		if copilotPath == "" {
+			copilotHome := strings.TrimSpace(os.Getenv("COPILOT_HOME"))
+			if copilotHome == "" {
+				copilotHome = filepath.Join(home, ".copilot")
+			}
+			copilotPath = filepath.Join(copilotHome, "hooks", "lazyworktree.json")
+		}
+	}
+	shim := agentEventShimCommand()
+
+	// Keep state hooks synchronous so their spool order matches agent events.
+	if err := installHooksFile(out, opts.DryRun, "Claude Code", claudePath,
+		[]string{"SessionStart", "UserPromptSubmit", "Stop", "SessionEnd"},
+		shim+" --agent claude", false, []agentHookMatcher{
+			{Event: "PreToolUse", Matcher: "AskUserQuestion"},
+			{Event: "PostToolUse", Matcher: "AskUserQuestion"},
+			{Event: "Elicitation", Matcher: "*"},
+			{Event: "ElicitationResult", Matcher: "*"},
+		}); err != nil {
+		return err
+	}
+	if err := installHooksFile(out, opts.DryRun, "Codex CLI", codexPath,
+		[]string{"SessionStart", "UserPromptSubmit", "Stop"},
+		shim+" --agent codex", false, nil); err != nil {
+		return err
+	}
+	if err := installCopilotHooksFile(out, opts.DryRun, copilotPath,
+		[]string{"SessionStart", "UserPromptSubmit", "Stop", "SessionEnd"},
+		shim+" --agent copilot", []agentHookMatcher{
+			{Event: "PreToolUse", Matcher: "AskUserQuestion"},
+			{Event: "PostToolUse", Matcher: "AskUserQuestion"},
+		}); err != nil {
+		return err
+	}
+	fmt.Fprintln(out, "\nNotes:")
+	fmt.Fprintln(out, "- Codex CLI requires approving new hooks with the /hooks command inside a Codex session.")
+	fmt.Fprintln(out, "- Copilot CLI loads hook files at startup; restart any running copilot session.")
+	return nil
+}
+
+// agentEventShimCommand returns the command used to invoke the hook shim. The
+// bare name is stable across upgrades, but is safe only when it resolves to
+// the executable currently installing the hooks.
+func agentEventShimCommand() string {
+	executable, err := os.Executable()
+	if err != nil {
+		return agentEventShimMarker
+	}
+	pathExecutable, _ := exec.LookPath("lazyworktree")
+	sameFile := false
+	if pathExecutable != "" {
+		executableInfo, executableErr := os.Stat(executable)
+		pathInfo, pathErr := os.Stat(pathExecutable)
+		sameFile = executableErr == nil && pathErr == nil && os.SameFile(executableInfo, pathInfo)
+	}
+	return chooseAgentEventShimCommand(executable, pathExecutable, sameFile)
+}
+
+func chooseAgentEventShimCommand(executable, pathExecutable string, sameFile bool) string {
+	if executable == "" {
+		return agentEventShimMarker
+	}
+	if pathExecutable != "" && sameFile {
+		return agentEventShimMarker
+	}
+	return quoteHookExecutable(executable) + " agent-event"
+}
+
+func installHooksFile(
+	out io.Writer,
+	dryRun bool,
+	label, path string,
+	events []string,
+	command string,
+	async bool,
+	matcherHooks []agentHookMatcher,
+) error {
+	root := map[string]any{}
+	data, err := os.ReadFile(path) //nolint:gosec // User-level config path.
+	switch {
+	case err == nil:
+		if len(bytes.TrimSpace(data)) > 0 {
+			if err := json.Unmarshal(data, &root); err != nil {
+				return fmt.Errorf("%s: parse %s: %w", label, path, err)
+			}
+		}
+	case os.IsNotExist(err):
+		data = nil
+	default:
+		return fmt.Errorf("%s: read %s: %w", label, path, err)
+	}
+
+	changed := mergeAgentHooks(root, events, command, async)
+	for _, hook := range matcherHooks {
+		changed = mergeAgentMatcherHook(root, hook.Event, hook.Matcher, command, async) || changed
+	}
+	if !changed {
+		fmt.Fprintf(out, "%s: hooks already installed in %s\n", label, path)
+		return nil
+	}
+	return writeHooksFile(out, dryRun, label, path, data, root)
+}
+
+// installCopilotHooksFile installs the shim into a Copilot CLI hook file
+// using its native flat entry format. Lifecycle events use PascalCase names
+// so the CLI emits VS Code compatible payloads; notification hooks retain
+// Copilot's native event name and are normalised by the shim.
+func installCopilotHooksFile(
+	out io.Writer,
+	dryRun bool,
+	path string,
+	events []string,
+	command string,
+	matcherHooks []agentHookMatcher,
+) error {
+	const label = "Copilot CLI"
+	root := map[string]any{}
+	data, err := os.ReadFile(path) //nolint:gosec // User-level config path.
+	switch {
+	case err == nil:
+		if len(bytes.TrimSpace(data)) > 0 {
+			if err := json.Unmarshal(data, &root); err != nil {
+				return fmt.Errorf("%s: parse %s: %w", label, path, err)
+			}
+		}
+	case os.IsNotExist(err):
+		data = nil
+	default:
+		return fmt.Errorf("%s: read %s: %w", label, path, err)
+	}
+
+	changed := mergeCopilotHooks(root, events, command)
+	for _, hook := range matcherHooks {
+		changed = mergeCopilotMatcherHook(root, hook.Event, hook.Matcher, command) || changed
+	}
+	if !changed {
+		fmt.Fprintf(out, "%s: hooks already installed in %s\n", label, path)
+		return nil
+	}
+	return writeHooksFile(out, dryRun, label, path, data, root)
+}
+
+// writeHooksFile encodes root and writes it to path, backing up any previous
+// content first. In dry-run mode it only prints the would-be content.
+func writeHooksFile(out io.Writer, dryRun bool, label, path string, previous []byte, root map[string]any) error {
+	updated, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return fmt.Errorf("%s: encode %s: %w", label, path, err)
+	}
+	updated = append(updated, '\n')
+
+	if dryRun {
+		fmt.Fprintf(out, "%s: would update %s with:\n%s\n", label, path, updated)
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return fmt.Errorf("%s: create config dir: %w", label, err)
+	}
+	if previous != nil {
+		backup := fmt.Sprintf("%s.bak-%s", path, time.Now().Format("20060102-150405"))
+		if err := os.WriteFile(backup, previous, 0o600); err != nil {
+			return fmt.Errorf("%s: write backup %s: %w", label, backup, err)
+		}
+		fmt.Fprintf(out, "%s: backed up existing config to %s\n", label, backup)
+	}
+	if err := writeConfigAtomically(path, updated); err != nil {
+		return fmt.Errorf("%s: write %s: %w", label, path, err)
+	}
+	fmt.Fprintf(out, "%s: installed hooks into %s\n", label, path)
+	return nil
+}
+
+// mergeCopilotHooks adds or repairs the shim command for each event in the
+// Copilot CLI native format: a flat entry list per event with a required
+// "version": 1 field at the top level. It reports whether anything changed.
+func mergeCopilotHooks(root map[string]any, events []string, command string) bool {
+	changed := false
+	if !isCopilotHooksVersionOne(root["version"]) {
+		root["version"] = 1
+		changed = true
+	}
+	hooks, ok := root["hooks"].(map[string]any)
+	if !ok {
+		hooks = map[string]any{}
+		root["hooks"] = hooks
+	}
+	for _, event := range events {
+		entries, _ := hooks[event].([]any)
+		found, updated := updateCopilotHook(entries, command)
+		if found {
+			changed = changed || updated
+			continue
+		}
+		entries = append(entries, map[string]any{"type": "command", "command": command})
+		hooks[event] = entries
+		changed = true
+	}
+	return changed
+}
+
+func isCopilotHooksVersionOne(value any) bool {
+	switch version := value.(type) {
+	case int:
+		return version == 1
+	case int64:
+		return version == 1
+	case float64:
+		return version == 1
+	case json.Number:
+		number, err := version.Float64()
+		return err == nil && number == 1
+	default:
+		return false
+	}
+}
+
+func mergeCopilotMatcherHook(root map[string]any, event, matcher, command string) bool {
+	hooks, ok := root["hooks"].(map[string]any)
+	if !ok {
+		hooks = map[string]any{}
+		root["hooks"] = hooks
+	}
+	entries, _ := hooks[event].([]any)
+	for _, entry := range entries {
+		entryMap, ok := entry.(map[string]any)
+		if !ok || entryMap["matcher"] != matcher {
+			continue
+		}
+		for _, field := range []string{"command", "bash", "powershell"} {
+			cmd, _ := entryMap[field].(string)
+			if !isAgentEventHookCommand(cmd) {
+				continue
+			}
+			if cmd == command {
+				return false
+			}
+			entryMap[field] = command
+			return true
+		}
+	}
+	hooks[event] = append(entries, map[string]any{
+		"type":    "command",
+		"matcher": matcher,
+		"command": command,
+	})
+	return true
+}
+
+func updateCopilotHook(entries []any, command string) (bool, bool) {
+	for _, entry := range entries {
+		entryMap, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		for _, field := range []string{"command", "bash", "powershell"} {
+			cmd, _ := entryMap[field].(string)
+			if !isAgentEventHookCommand(cmd) {
+				continue
+			}
+			changed := false
+			if cmd != command {
+				entryMap[field] = command
+				changed = true
+			}
+			return true, changed
+		}
+	}
+	return false, false
+}
+
+// mergeAgentHooks adds or repairs the shim command for each event. It reports
+// whether anything changed.
+func mergeAgentHooks(root map[string]any, events []string, command string, async bool) bool {
+	hooks, ok := root["hooks"].(map[string]any)
+	if !ok {
+		hooks = map[string]any{}
+		root["hooks"] = hooks
+	}
+	changed := false
+	for _, event := range events {
+		groups, _ := hooks[event].([]any)
+		found, updated := updateAgentHook(groups, command, async)
+		if found {
+			changed = changed || updated
+			continue
+		}
+		handler := map[string]any{"type": "command", "command": command}
+		if async {
+			handler["async"] = true
+		}
+		groups = append(groups, map[string]any{"hooks": []any{handler}})
+		hooks[event] = groups
+		changed = true
+	}
+	return changed
+}
+
+func mergeAgentMatcherHook(root map[string]any, event, matcher, command string, async bool) bool {
+	hooks, ok := root["hooks"].(map[string]any)
+	if !ok {
+		hooks = map[string]any{}
+		root["hooks"] = hooks
+	}
+	groups, _ := hooks[event].([]any)
+	for _, group := range groups {
+		groupMap, ok := group.(map[string]any)
+		if !ok || groupMap["matcher"] != matcher {
+			continue
+		}
+		if found, updated := updateAgentHook([]any{group}, command, async); found {
+			return updated
+		}
+		handler := map[string]any{"type": "command", "command": command}
+		if async {
+			handler["async"] = true
+		}
+		handlers, _ := groupMap["hooks"].([]any)
+		groupMap["hooks"] = append(handlers, handler)
+		return true
+	}
+	handler := map[string]any{"type": "command", "command": command}
+	if async {
+		handler["async"] = true
+	}
+	hooks[event] = append(groups, map[string]any{
+		"matcher": matcher,
+		"hooks":   []any{handler},
+	})
+	return true
+}
+
+func updateAgentHook(groups []any, command string, async bool) (bool, bool) {
+	for _, group := range groups {
+		groupMap, ok := group.(map[string]any)
+		if !ok {
+			continue
+		}
+		handlers, _ := groupMap["hooks"].([]any)
+		for _, handler := range handlers {
+			handlerMap, ok := handler.(map[string]any)
+			if !ok {
+				continue
+			}
+			cmd, _ := handlerMap["command"].(string)
+			if isAgentEventHookCommand(cmd) {
+				changed := false
+				if cmd != command {
+					handlerMap["command"] = command
+					changed = true
+				}
+				if async {
+					if current, ok := handlerMap["async"].(bool); !ok || !current {
+						handlerMap["async"] = true
+						changed = true
+					}
+				} else if _, ok := handlerMap["async"]; ok {
+					delete(handlerMap, "async")
+					changed = true
+				}
+				return true, changed
+			}
+		}
+	}
+	return false, false
+}
+
+func writeConfigAtomically(path string, data []byte) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
+func isAgentEventHookCommand(command string) bool {
+	parts, err := shlex.Split(command)
+	if err != nil || len(parts) < 2 {
+		return false
+	}
+	executable := filepath.Base(parts[0])
+	if strings.EqualFold(filepath.Ext(executable), ".exe") {
+		executable = strings.TrimSuffix(executable, filepath.Ext(executable))
+	}
+	if parts[1] != "agent-event" {
+		return false
+	}
+	if strings.EqualFold(executable, "lazyworktree") {
+		return true
+	}
+	current, err := os.Executable()
+	if err == nil && strings.EqualFold(filepath.Clean(parts[0]), filepath.Clean(current)) {
+		return true
+	}
+	return false
+}

--- a/internal/commands/agenthooks_test.go
+++ b/internal/commands/agenthooks_test.go
@@ -1,0 +1,431 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func setupHooksTestOpts(t *testing.T, dryRun bool) (SetupAgentHooksOptions, *bytes.Buffer) {
+	t.Helper()
+	dir := t.TempDir()
+	out := &bytes.Buffer{}
+	return SetupAgentHooksOptions{
+		DryRun:             dryRun,
+		ClaudeSettingsPath: filepath.Join(dir, "claude", "settings.json"),
+		CodexHooksPath:     filepath.Join(dir, "codex", "hooks.json"),
+		CopilotHooksPath:   filepath.Join(dir, "copilot", "hooks", "lazyworktree.json"),
+		Stdout:             out,
+	}, out
+}
+
+func readHooksFile(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path) //nolint:gosec // Test path.
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var root map[string]any
+	if err := json.Unmarshal(data, &root); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	return root
+}
+
+func hasMatcherHook(groups []any, matcher, agent string) bool {
+	for _, group := range groups {
+		groupMap, _ := group.(map[string]any)
+		if groupMap["matcher"] != matcher {
+			continue
+		}
+		handlers, _ := groupMap["hooks"].([]any)
+		for _, handler := range handlers {
+			handlerMap, _ := handler.(map[string]any)
+			command, _ := handlerMap["command"].(string)
+			if strings.Contains(command, "agent-event") && strings.Contains(command, "--agent "+agent) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func matcherHookIsSynchronous(groups []any, matcher string) bool {
+	for _, group := range groups {
+		groupMap, _ := group.(map[string]any)
+		groupMatcher, _ := groupMap["matcher"].(string)
+		if groupMatcher != matcher {
+			continue
+		}
+		handlers, _ := groupMap["hooks"].([]any)
+		for _, handler := range handlers {
+			handlerMap, _ := handler.(map[string]any)
+			command, _ := handlerMap["command"].(string)
+			if isAgentEventHookCommand(command) {
+				_, async := handlerMap["async"]
+				return !async
+			}
+		}
+	}
+	return false
+}
+
+func TestSetupAgentHooksInstallsBothConfigs(t *testing.T) {
+	opts, _ := setupHooksTestOpts(t, false)
+	if err := SetupAgentHooks(opts); err != nil {
+		t.Fatalf("setup failed: %v", err)
+	}
+
+	claude := readHooksFile(t, opts.ClaudeSettingsPath)
+	hooks, _ := claude["hooks"].(map[string]any)
+	for _, event := range []string{"SessionStart", "UserPromptSubmit", "Stop", "SessionEnd"} {
+		if _, ok := hooks[event]; !ok {
+			t.Fatalf("claude settings missing %s hook", event)
+		}
+	}
+	claudeSessionStart, _ := hooks["SessionStart"].([]any)
+	if !matcherHookIsSynchronous(claudeSessionStart, "") {
+		t.Fatal("claude lifecycle hooks must be synchronous")
+	}
+	claudePreTool, _ := hooks["PreToolUse"].([]any)
+	if !hasMatcherHook(claudePreTool, "AskUserQuestion", "claude") {
+		t.Fatal("claude settings missing question-open hook")
+	}
+	if !matcherHookIsSynchronous(claudePreTool, "AskUserQuestion") {
+		t.Fatal("claude question-open hook must be synchronous")
+	}
+	claudePostTool, _ := hooks["PostToolUse"].([]any)
+	if !hasMatcherHook(claudePostTool, "AskUserQuestion", "claude") {
+		t.Fatal("claude settings missing question completion hook")
+	}
+	if !matcherHookIsSynchronous(claudePostTool, "AskUserQuestion") {
+		t.Fatal("claude question completion hook must be synchronous")
+	}
+	for _, event := range []string{"Elicitation", "ElicitationResult"} {
+		groups, _ := hooks[event].([]any)
+		if !hasMatcherHook(groups, "*", "claude") {
+			t.Fatalf("claude settings missing %s hook", event)
+		}
+	}
+
+	codex := readHooksFile(t, opts.CodexHooksPath)
+	codexHooks, _ := codex["hooks"].(map[string]any)
+	for _, event := range []string{"SessionStart", "UserPromptSubmit", "Stop"} {
+		if _, ok := codexHooks[event]; !ok {
+			t.Fatalf("codex hooks missing %s", event)
+		}
+	}
+	if _, ok := codexHooks["SessionEnd"]; ok {
+		t.Fatal("codex has no SessionEnd event; must not be installed")
+	}
+
+	copilot := readHooksFile(t, opts.CopilotHooksPath)
+	if version, ok := copilot["version"].(float64); !ok || version != 1 {
+		t.Fatalf("copilot hooks missing version 1, got %v", copilot["version"])
+	}
+	copilotHooks, _ := copilot["hooks"].(map[string]any)
+	for _, event := range []string{"SessionStart", "UserPromptSubmit", "Stop", "SessionEnd"} {
+		entries, ok := copilotHooks[event].([]any)
+		if !ok || len(entries) != 1 {
+			t.Fatalf("copilot hooks missing %s entry", event)
+		}
+		entry, _ := entries[0].(map[string]any)
+		if entry["type"] != "command" {
+			t.Fatalf("copilot %s entry has wrong type %v", event, entry["type"])
+		}
+		command, _ := entry["command"].(string)
+		if !strings.Contains(command, "agent-event") || !strings.Contains(command, "--agent copilot") {
+			t.Fatalf("copilot %s entry has wrong command %q", event, command)
+		}
+	}
+	copilotPreTool, _ := copilotHooks["PreToolUse"].([]any)
+	if len(copilotPreTool) != 1 || copilotPreTool[0].(map[string]any)["matcher"] != "AskUserQuestion" {
+		t.Fatal("copilot hooks missing AskUserQuestion question-open hook")
+	}
+	copilotPostTool, _ := copilotHooks["PostToolUse"].([]any)
+	if len(copilotPostTool) != 1 || copilotPostTool[0].(map[string]any)["matcher"] != "AskUserQuestion" {
+		t.Fatal("copilot hooks missing AskUserQuestion completion hook")
+	}
+}
+
+func TestSetupAgentHooksIsIdempotent(t *testing.T) {
+	opts, _ := setupHooksTestOpts(t, false)
+	if err := SetupAgentHooks(opts); err != nil {
+		t.Fatalf("first run failed: %v", err)
+	}
+	paths := []string{opts.ClaudeSettingsPath, opts.CodexHooksPath, opts.CopilotHooksPath}
+	first := make([][]byte, len(paths))
+	for i, path := range paths {
+		first[i], _ = os.ReadFile(path) //nolint:gosec // Test-owned temporary path.
+	}
+
+	opts.Stdout = &bytes.Buffer{}
+	if err := SetupAgentHooks(opts); err != nil {
+		t.Fatalf("second run failed: %v", err)
+	}
+	for i, path := range paths {
+		second, _ := os.ReadFile(path) //nolint:gosec // Test-owned temporary path.
+		if !bytes.Equal(first[i], second) {
+			t.Fatalf("second run modified %s", path)
+		}
+	}
+	out := opts.Stdout.(*bytes.Buffer).String()
+	if !strings.Contains(out, "already installed") {
+		t.Fatalf("expected already-installed notice, got: %s", out)
+	}
+}
+
+func TestSetupAgentHooksPreservesExistingSettings(t *testing.T) {
+	opts, _ := setupHooksTestOpts(t, false)
+	if err := os.MkdirAll(filepath.Dir(opts.ClaudeSettingsPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	existing := `{"model":"opus","hooks":{"PreToolUse":[{"hooks":[{"type":"command","command":"echo hi"}]}]}}`
+	if err := os.WriteFile(opts.ClaudeSettingsPath, []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := SetupAgentHooks(opts); err != nil {
+		t.Fatalf("setup failed: %v", err)
+	}
+	root := readHooksFile(t, opts.ClaudeSettingsPath)
+	if root["model"] != "opus" {
+		t.Fatal("existing top-level settings lost")
+	}
+	hooks, _ := root["hooks"].(map[string]any)
+	if _, ok := hooks["PreToolUse"]; !ok {
+		t.Fatal("existing hook entries lost")
+	}
+	if _, ok := hooks["SessionStart"]; !ok {
+		t.Fatal("new hook entries missing")
+	}
+
+	backups, _ := filepath.Glob(opts.ClaudeSettingsPath + ".bak-*")
+	if len(backups) != 1 {
+		t.Fatalf("expected one backup, got %d", len(backups))
+	}
+}
+
+func TestSetupAgentHooksDryRunWritesNothing(t *testing.T) {
+	opts, out := setupHooksTestOpts(t, true)
+	if err := SetupAgentHooks(opts); err != nil {
+		t.Fatalf("dry run failed: %v", err)
+	}
+	if _, err := os.Stat(opts.ClaudeSettingsPath); !os.IsNotExist(err) {
+		t.Fatal("dry run must not write claude settings")
+	}
+	if _, err := os.Stat(opts.CodexHooksPath); !os.IsNotExist(err) {
+		t.Fatal("dry run must not write codex hooks")
+	}
+	if _, err := os.Stat(opts.CopilotHooksPath); !os.IsNotExist(err) {
+		t.Fatal("dry run must not write copilot hooks")
+	}
+	if !strings.Contains(out.String(), "would update") {
+		t.Fatalf("expected dry-run preview, got: %s", out.String())
+	}
+}
+
+func TestSetupAgentHooksHonoursCodexHome(t *testing.T) {
+	root := t.TempDir()
+	codexHome := filepath.Join(root, "custom-codex")
+	t.Setenv("CODEX_HOME", codexHome)
+	t.Setenv("COPILOT_HOME", filepath.Join(root, "copilot"))
+	opts := SetupAgentHooksOptions{
+		ClaudeSettingsPath: filepath.Join(root, "claude", "settings.json"),
+		Stdout:             &bytes.Buffer{},
+	}
+	if err := SetupAgentHooks(opts); err != nil {
+		t.Fatalf("setup failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(codexHome, "hooks.json")); err != nil {
+		t.Fatalf("expected hooks under CODEX_HOME: %v", err)
+	}
+}
+
+func TestSetupAgentHooksHonoursCopilotHome(t *testing.T) {
+	root := t.TempDir()
+	copilotHome := filepath.Join(root, "custom-copilot")
+	t.Setenv("COPILOT_HOME", copilotHome)
+	t.Setenv("CODEX_HOME", filepath.Join(root, "codex"))
+	opts := SetupAgentHooksOptions{
+		ClaudeSettingsPath: filepath.Join(root, "claude", "settings.json"),
+		Stdout:             &bytes.Buffer{},
+	}
+	if err := SetupAgentHooks(opts); err != nil {
+		t.Fatalf("setup failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(copilotHome, "hooks", "lazyworktree.json")); err != nil {
+		t.Fatalf("expected hooks under COPILOT_HOME: %v", err)
+	}
+}
+
+func TestChooseAgentEventShimCommand(t *testing.T) {
+	if got := chooseAgentEventShimCommand("/current/lazyworktree", "/on/path/lazyworktree", true); got != agentEventShimMarker {
+		t.Fatalf("expected stable bare command for matching PATH executable, got %q", got)
+	}
+
+	executable := filepath.Join(string(filepath.Separator), "tmp", "Lazy Worktree", "lazyworktree")
+	want := quoteHookExecutable(executable) + " agent-event"
+	if got := chooseAgentEventShimCommand(executable, "/old/lazyworktree", false); got != want {
+		t.Fatalf("expected quoted current executable %q, got %q", want, got)
+	}
+}
+
+func TestMergeAgentHooksRepairsExistingCommand(t *testing.T) {
+	handler := map[string]any{
+		"type":    "command",
+		"command": "/old/lazyworktree agent-event --agent codex",
+		"async":   true,
+	}
+	root := map[string]any{
+		"hooks": map[string]any{
+			"Stop": []any{map[string]any{"hooks": []any{handler}}},
+		},
+	}
+	command := "'/new/Lazy Worktree/lazyworktree' agent-event --agent codex"
+	if changed := mergeAgentHooks(root, []string{"Stop"}, command, false); !changed {
+		t.Fatal("expected stale hook command to be repaired")
+	}
+	if got := handler["command"]; got != command {
+		t.Fatalf("expected repaired command %q, got %q", command, got)
+	}
+	if _, ok := handler["async"]; ok {
+		t.Fatal("expected unsupported async setting to be removed")
+	}
+	if changed := mergeAgentHooks(root, []string{"Stop"}, command, false); changed {
+		t.Fatal("expected repaired hook to be idempotent")
+	}
+}
+
+func TestMergeAgentHooksDoesNotRewriteUnrelatedAgentEvent(t *testing.T) {
+	handler := map[string]any{
+		"type":    "command",
+		"command": "other-tool agent-event --agent codex",
+	}
+	root := map[string]any{
+		"hooks": map[string]any{
+			"Stop": []any{map[string]any{"hooks": []any{handler}}},
+		},
+	}
+	command := "lazyworktree agent-event --agent codex"
+	if changed := mergeAgentHooks(root, []string{"Stop"}, command, false); !changed {
+		t.Fatal("expected lazyworktree hook to be added")
+	}
+	if got := handler["command"]; got != "other-tool agent-event --agent codex" {
+		t.Fatalf("unrelated hook was rewritten to %q", got)
+	}
+}
+
+func TestMergeCopilotHooksRepairsExistingCommand(t *testing.T) {
+	entry := map[string]any{
+		"type":    "command",
+		"command": "/old/lazyworktree agent-event --agent copilot",
+	}
+	root := map[string]any{
+		"version": float64(1),
+		"hooks": map[string]any{
+			"Stop": []any{entry},
+		},
+	}
+	command := "'/new/Lazy Worktree/lazyworktree' agent-event --agent copilot"
+	if changed := mergeCopilotHooks(root, []string{"Stop"}, command); !changed {
+		t.Fatal("expected stale hook command to be repaired")
+	}
+	if got := entry["command"]; got != command {
+		t.Fatalf("expected repaired command %q, got %q", command, got)
+	}
+	if changed := mergeCopilotHooks(root, []string{"Stop"}, command); changed {
+		t.Fatal("expected repaired hook to be idempotent")
+	}
+}
+
+func TestMergeCopilotHooksPreservesForeignEntries(t *testing.T) {
+	foreign := map[string]any{
+		"type":    "command",
+		"command": "other-tool agent-event --agent copilot",
+	}
+	root := map[string]any{
+		"version": float64(1),
+		"hooks": map[string]any{
+			"Stop": []any{foreign},
+		},
+	}
+	command := "lazyworktree agent-event --agent copilot"
+	if changed := mergeCopilotHooks(root, []string{"Stop"}, command); !changed {
+		t.Fatal("expected lazyworktree hook to be added")
+	}
+	if got := foreign["command"]; got != "other-tool agent-event --agent copilot" {
+		t.Fatalf("foreign hook was rewritten to %q", got)
+	}
+	entries, _ := root["hooks"].(map[string]any)["Stop"].([]any)
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+}
+
+func TestMergeCopilotHooksSetsVersion(t *testing.T) {
+	root := map[string]any{}
+	command := "lazyworktree agent-event --agent copilot"
+	if changed := mergeCopilotHooks(root, []string{"SessionStart"}, command); !changed {
+		t.Fatal("expected change on empty config")
+	}
+	if root["version"] != 1 {
+		t.Fatalf("expected version 1, got %v", root["version"])
+	}
+	if changed := mergeCopilotHooks(root, []string{"SessionStart"}, command); changed {
+		t.Fatal("expected repeated merge on the same map to be idempotent")
+	}
+}
+
+func TestIsCopilotHooksVersionOne(t *testing.T) {
+	for _, version := range []any{1, int64(1), float64(1), json.Number("1")} {
+		if !isCopilotHooksVersionOne(version) {
+			t.Fatalf("expected version %T(%v) to be accepted", version, version)
+		}
+	}
+	for _, version := range []any{nil, 2, float64(1.5), json.Number("invalid"), "1"} {
+		if isCopilotHooksVersionOne(version) {
+			t.Fatalf("expected version %T(%v) to be rejected", version, version)
+		}
+	}
+}
+
+func TestSetupAgentHooksEmptyConfigFile(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{"zero bytes", ""},
+		{"whitespace only", "  \n\t\n  "},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts, _ := setupHooksTestOpts(t, false)
+			for _, path := range []string{opts.ClaudeSettingsPath, opts.CodexHooksPath, opts.CopilotHooksPath} {
+				if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(path, []byte(tt.content), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := SetupAgentHooks(opts); err != nil {
+				t.Fatalf("setup with %s config failed: %v", tt.name, err)
+			}
+			claude := readHooksFile(t, opts.ClaudeSettingsPath)
+			hooks, _ := claude["hooks"].(map[string]any)
+			if _, ok := hooks["SessionStart"]; !ok {
+				t.Fatal("hooks not installed into empty claude config")
+			}
+		})
+	}
+}
+
+func TestIsAgentEventHookCommandCopilot(t *testing.T) {
+	if !isAgentEventHookCommand("/some/path/lazyworktree agent-event --agent copilot") {
+		t.Fatal("expected copilot shim command to be recognised")
+	}
+}

--- a/internal/commands/agenthooks_unix.go
+++ b/internal/commands/agenthooks_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package commands
+
+import "github.com/chmouel/lazyworktree/internal/multiplexer"
+
+func quoteHookExecutable(path string) string {
+	return multiplexer.ShellQuote(path)
+}

--- a/internal/commands/agenthooks_windows.go
+++ b/internal/commands/agenthooks_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package commands
+
+import "strings"
+
+func quoteHookExecutable(path string) string {
+	return `"` + strings.ReplaceAll(path, `"`, `""`) + `"`
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,6 +73,7 @@ type AppConfig struct {
 	AgentSessionClaudeRoot  string // Custom root for Claude transcript discovery (default: ~/.claude/projects)
 	AgentSessionPiRoot      string // Custom root for pi transcript discovery (default: ~/.pi/agent/sessions)
 	AgentSessionsDisabled   bool   // Disable the Agent Sessions pane and transcript watching (default: false)
+	AgentProcessScan        bool   // Deprecated: opt in to ps/lsof process scanning for agent liveness (default: false; prefer setup-hooks)
 	AgentRefreshDebounceMs  int    // Debounce window (ms) for agent transcript refreshes (default: 600; 0 disables throttling)
 	CustomCreateMenus       []*CustomCreateMenu
 	CustomThemes            map[string]*CustomTheme // User-defined custom themes
@@ -224,6 +225,7 @@ func parseConfig(data map[string]any) (*AppConfig, error) {
 			}
 		}
 		cfg.AgentSessionsDisabled = coerceBool(agentData["disabled"], cfg.AgentSessionsDisabled)
+		cfg.AgentProcessScan = coerceBool(agentData["process_scan"], cfg.AgentProcessScan)
 		cfg.AgentRefreshDebounceMs = coerceInt(agentData["refresh_debounce_ms"], cfg.AgentRefreshDebounceMs)
 	}
 
@@ -629,6 +631,9 @@ func (cfg *AppConfig) ApplyCLIOverrides(overrides []string) error {
 	}
 	if overrideNestedData(overrideData, "agent_sessions", "disabled") {
 		cfg.AgentSessionsDisabled = overrideCfg.AgentSessionsDisabled
+	}
+	if overrideNestedData(overrideData, "agent_sessions", "process_scan") {
+		cfg.AgentProcessScan = overrideCfg.AgentProcessScan
 	}
 	if overrideNestedData(overrideData, "agent_sessions", "refresh_debounce_ms") {
 		cfg.AgentRefreshDebounceMs = overrideCfg.AgentRefreshDebounceMs

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1291,6 +1291,26 @@ func TestParseConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "agent_sessions process_scan opt-in parsed",
+			data: map[string]interface{}{
+				"agent_sessions": map[string]any{
+					"process_scan": true,
+				},
+			},
+			validate: func(t *testing.T, cfg *AppConfig) {
+				assert.True(t, cfg.AgentProcessScan)
+			},
+		},
+		{
+			name: "agent_sessions process_scan defaults to false",
+			data: map[string]interface{}{
+				"agent_sessions": map[string]any{},
+			},
+			validate: func(t *testing.T, cfg *AppConfig) {
+				assert.False(t, cfg.AgentProcessScan)
+			},
+		},
+		{
 			name: "agent_sessions absent defaults to empty",
 			data: map[string]interface{}{},
 			validate: func(t *testing.T, cfg *AppConfig) {

--- a/internal/models/agent_hook_event.go
+++ b/internal/models/agent_hook_event.go
@@ -1,0 +1,33 @@
+package models
+
+import "time"
+
+// AgentHookEventSchemaVersion identifies the spool event format.
+const AgentHookEventSchemaVersion = "lazyworktree-agent-hook-event-v1"
+
+// AgentHookEvent is a normalised agent lifecycle event written to the spool
+// directory by the hidden `agent-event` hook shim and consumed by the TUI.
+type AgentHookEvent struct {
+	SchemaVersion  string    `json:"schema_version"`
+	Agent          AgentKind `json:"agent"`
+	HookEventName  string    `json:"hook_event_name"`
+	SessionID      string    `json:"session_id"`
+	TranscriptPath string    `json:"transcript_path,omitempty"`
+	CWD            string    `json:"cwd,omitempty"`
+	Model          string    `json:"model,omitempty"`
+	Source         string    `json:"source,omitempty"`
+	PID            int       `json:"pid,omitempty"`
+	Timestamp      time.Time `json:"timestamp"`
+}
+
+// Hook event names shared by the Claude Code, Codex CLI, and Copilot CLI
+// hook systems. Copilot CLI emits these when its hooks are configured with
+// the PascalCase (VS Code compatible) event names.
+const (
+	AgentHookSessionStart     = "SessionStart"
+	AgentHookSessionEnd       = "SessionEnd"
+	AgentHookStop             = "Stop"
+	AgentHookUserPromptSubmit = "UserPromptSubmit"
+	AgentHookWaitingForUser   = "WaitingForUser"
+	AgentHookCwdChanged       = "CwdChanged"
+)

--- a/internal/models/agent_session.go
+++ b/internal/models/agent_session.go
@@ -10,6 +10,10 @@ const (
 	AgentKindClaude AgentKind = "claude"
 	// AgentKindPi marks a transcript produced by pi.
 	AgentKindPi AgentKind = "pi"
+	// AgentKindCodex marks a session produced by the OpenAI Codex CLI.
+	AgentKindCodex AgentKind = "codex"
+	// AgentKindCopilot marks a session produced by the GitHub Copilot CLI.
+	AgentKindCopilot AgentKind = "copilot"
 )
 
 // AgentSessionStatus describes the last observable state of a transcript.
@@ -98,11 +102,13 @@ const (
 	AgentSessionLivenessSourceExactFile AgentSessionLivenessSource = "exact_file"
 	// AgentSessionLivenessSourceCWDHeuristic means the match came only from a working-directory heuristic.
 	AgentSessionLivenessSourceCWDHeuristic AgentSessionLivenessSource = "cwd_heuristic"
+	// AgentSessionLivenessSourceHook means an agent lifecycle hook reported the session.
+	AgentSessionLivenessSourceHook AgentSessionLivenessSource = "hook"
 	// AgentSessionLivenessSourceNone means no evidence was available.
 	AgentSessionLivenessSourceNone AgentSessionLivenessSource = "none"
 )
 
-// AgentSession summarises a Claude or pi transcript attached to a worktree.
+// AgentSession summarises a coding-agent session attached to a worktree.
 type AgentSession struct {
 	ID             string
 	SessionKey     string
@@ -130,6 +136,8 @@ type AgentSession struct {
 	LivenessSource AgentSessionLivenessSource
 	ResumeHint     string
 	SchemaVersion  string
+	// PID is the agent process id reported by a lifecycle hook, when known.
+	PID            int
 	IsOpen         bool
 	OpenConfidence AgentOpenConfidence
 }

--- a/lazyworktree.1
+++ b/lazyworktree.1
@@ -406,6 +406,29 @@ Emit the CLI command structure as machine-readable JSON. Designed for coding age
 .B \-\-all
 Describe all commands and their flags (equivalent to no arguments).
 .
+.SS setup-hooks
+Install agent session hooks for Claude Code, the Codex CLI, and the Copilot CLI.
+.
+.PP
+.B Synopsis:
+.PP
+.B lazyworktree setup\-hooks \fR[\fB\-\-dry\-run\fR]
+.
+.PP
+The setup\-hooks command adds lifecycle hooks to \fB~/.claude/settings.json\fR, \fB$CODEX_HOME/hooks.json\fR (or \fB~/.codex/hooks.json\fR when \fBCODEX_HOME\fR is unset), and \fB$COPILOT_HOME/hooks/lazyworktree.json\fR (or \fB~/.copilot/hooks/lazyworktree.json\fR when \fBCOPILOT_HOME\fR is unset) so that agent sessions report their state directly to lazyworktree. Hook events provide precise, low\-cost session tracking and enable Codex CLI and Copilot CLI sessions to appear in the agents pane. Claude Code and Copilot CLI hooks also report question dialogs, allowing lazyworktree to show when an agent is waiting for user input rather than thinking. Codex CLI does not currently expose an equivalent question\-dialog hook. Existing settings are preserved and a timestamped backup is written before any modification. The command is idempotent.
+.
+.PP
+Hook events are the default liveness source. The former process\-table scan (ps/lsof) is deprecated and disabled by default; it may be re\-enabled with the \fBagent_sessions.process_scan\fR configuration key.
+.
+.PP
+The Codex CLI requires newly installed hooks to be approved with the \fB/hooks\fR command inside a Codex session. The Copilot CLI loads hook files at startup, so restart any running copilot session after installing.
+.
+.PP
+.B Options:
+.TP
+.B \-\-dry\-run
+Show the configuration changes without writing any files.
+.
 .SH EXAMPLES
 .SS Worktree Management
 List worktrees (table format):
@@ -696,7 +719,7 @@ selected worktree has a note.
 .TP
 .B 6
 Switch to Agent Sessions pane (toggle zoom if already focused). Only visible
-when open Claude or pi sessions are attached to the selected worktree by
+when open Claude, Codex, Copilot, or pi sessions are attached to the selected worktree by
 default. Pressing \fB6\fR also reveals historical matching sessions when nothing
 is currently open; pressing \fBA\fR inside the pane toggles between open-only
 and all matching sessions. Tab cycling includes this pane last when visible.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -129,6 +129,7 @@ nav:
       - exec: cli/exec.md
       - note: cli/note.md
       - describe: cli/describe.md
+      - setup-hooks: cli/setup-hooks.md
 extra:
   generator: false
   social:


### PR DESCRIPTION
## Summary

Adds lifecycle-hook-based agent session tracking for Claude Code, OpenAI Codex CLI, and GitHub Copilot CLI. Hooks provide authoritative session state and inexpensive PID liveness checks, replacing periodic process-table discovery as the default.

## Release note

Users are now encouraged to run the following command after installing or upgrading lazyworktree:

```bash
lazyworktree setup-hooks
```

Hook-based tracking is now the recommended way to obtain accurate, low-cost agent session status. The command currently configures Claude Code, Codex CLI, and Copilot CLI. Pi hook integration is intentionally deferred and will follow in a later release; existing Pi transcript support remains unchanged.

## Changes

- Adds `lazyworktree setup-hooks` with `--dry-run` support.
- Installs user-level hooks into:
  - Claude Code: `~/.claude/settings.json`
  - Codex CLI: `$CODEX_HOME/hooks.json` or `~/.codex/hooks.json`
  - Copilot CLI: `$COPILOT_HOME/hooks/lazyworktree.json` or `~/.copilot/hooks/lazyworktree.json`
- Preserves existing hook configuration, creates timestamped backups, repairs stale lazyworktree entries, and remains idempotent across repeated runs.
- Adds the hidden `agent-event` shim and an atomic event spool consumed by the TUI watcher.
- Synthesises Codex and Copilot sessions directly from hook events, without depending on unstable transcript formats.
- Adds Copilot CLI process classification and session presentation.
- Tracks question-dialog state for Claude Code and Copilot CLI:
  - `PreToolUse(AskUserQuestion)` reports **waiting**.
  - `PostToolUse(AskUserQuestion)` reports **thinking** after an answer.
  - Claude MCP `Elicitation` and `ElicitationResult` receive the same treatment.
- Keeps ordering-sensitive Claude state hooks synchronous so events cannot arrive out of order.
- Makes the former `ps`/`lsof` process scan deprecated and disabled by default. It remains available through:

  ```yaml
  agent_sessions:
    process_scan: true
  ```

## Agent-specific notes

- Codex CLI requires hook approval through `/hooks` after installation.
- Copilot CLI loads hook files at startup, so existing sessions must be restarted.
- Codex currently exposes no equivalent question-dialog hook, so waiting-for-question state is available for Claude Code and Copilot CLI only.
- Hook-based Pi integration will be added later; existing transcript-based Pi support is unchanged.
- Hook PID probes remain enabled; only the broad process-table scan became opt-in.

## Safety and compatibility

- Hook payloads are size-limited and written atomically to an owner-only state directory.
- The shim always exits successfully so tracking failures cannot interrupt an agent session.
- Unix and Windows process/PID handling are implemented separately.
- Existing Claude, Codex, and Copilot hook entries are merged rather than replaced.

## Documentation

Updates the CLI reference, configuration reference, AI integration guide, man page, internal help, and generated documentation. Adds a dedicated `setup-hooks` guide.

## Testing

- `make sanity`
- `make docs-check`
