### PR TITLE
fix: Prevent split worktree notes from overwriting concurrent edits

### DIFF
--- a/docs/worktree-notes.md
+++ b/docs/worktree-notes.md
@@ -75,6 +75,10 @@ Supports **markdown**.
 
 This makes notes easy to browse, search, and edit with external tools.
 
+#### Concurrent edits in splitted mode
+
+Splitted mode is safe for concurrent access from multiple processes or clones. Saving a note writes or removes only that worktree's file — other note files on disk are left untouched, even if they were created after lazyworktree last read the directory. This means a stale in-memory view in one process cannot delete or overwrite a note written by another. Removing a note is always an explicit action rather than an implicit side effect of a batch save.
+
 ## Example script: PR details to LLM note
 
 For more control, point `worktree_note_script` to your own script. The script can receive PR title/body on stdin, call your preferred LLM, and return a concise note.

--- a/internal/app/services/persistence.go
+++ b/internal/app/services/persistence.go
@@ -405,10 +405,7 @@ func SaveWorktreeNotes(repoKey, worktreeDir, worktreeNotesPath, noteType string,
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(worktreeNotesPath, data, defaultFilePerms); err != nil {
-		return err
-	}
-	return nil
+	return writeAtomically(worktreeNotesPath, data)
 }
 
 func normalizeWorktreeNotes(notes map[string]models.WorktreeNote) map[string]models.WorktreeNote {
@@ -418,10 +415,7 @@ func normalizeWorktreeNotes(notes map[string]models.WorktreeNote) map[string]mod
 
 	normalized := make(map[string]models.WorktreeNote, len(notes))
 	for noteKey, note := range notes {
-		note.Note = strings.TrimSpace(note.Note)
-		note.Icon = strings.TrimSpace(note.Icon)
-		note.Color = worktreecolor.Normalize(note.Color)
-		note.Tags = models.NormalizeTags(note.Tags)
+		note = normalizeWorktreeNote(note)
 		if note.IsEmpty() {
 			continue
 		}
@@ -430,11 +424,40 @@ func normalizeWorktreeNotes(notes map[string]models.WorktreeNote) map[string]mod
 	return normalized
 }
 
+func normalizeWorktreeNote(note models.WorktreeNote) models.WorktreeNote {
+	note.Note = strings.TrimSpace(note.Note)
+	note.Icon = strings.TrimSpace(note.Icon)
+	note.Color = worktreecolor.Normalize(note.Color)
+	note.Tags = models.NormalizeTags(note.Tags)
+	return note
+}
+
+// SaveWorktreeNoteEntry persists a single note entry identified by key.
+// For splitted mode it writes or removes only that worktree's file, leaving
+// other note files untouched so concurrent writers cannot be clobbered by a
+// stale in-memory map. For other modes it saves the full map.
+func SaveWorktreeNoteEntry(repoKey, worktreeDir, worktreeNotesPath, noteType, key string, notes map[string]models.WorktreeNote, env map[string]string) error {
+	if noteType == config.NoteTypeSplitted {
+		note, ok := notes[key]
+		if ok {
+			note = normalizeWorktreeNote(note)
+		}
+		if !ok || note.IsEmpty() {
+			return DeleteSplittedNoteFile(worktreeNotesPath, key, env)
+		}
+		return writeSplittedNoteFile(worktreeNotesPath, key, note, env)
+	}
+	return SaveWorktreeNotes(repoKey, worktreeDir, worktreeNotesPath, noteType, notes, env)
+}
+
 func loadRepoWorktreeNotes(notesPath string) (map[string]models.WorktreeNote, error) {
 	// #nosec G304 -- notesPath is constructed from vetted directory and constant filename
 	data, err := os.ReadFile(notesPath)
 	if err != nil {
-		return map[string]models.WorktreeNote{}, nil
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]models.WorktreeNote{}, nil
+		}
+		return nil, err
 	}
 
 	var notes map[string]models.WorktreeNote
@@ -463,17 +486,17 @@ func saveRepoWorktreeNotes(notesPath string, notes map[string]models.WorktreeNot
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(notesPath, data, defaultFilePerms); err != nil {
-		return err
-	}
-	return nil
+	return writeAtomically(notesPath, data)
 }
 
 func loadSharedWorktreeNotes(repoKey, worktreeNotesPath string) (map[string]map[string]models.WorktreeNote, error) {
 	// #nosec G304 -- path is user-configured and intentionally read for persistence
 	data, err := os.ReadFile(worktreeNotesPath)
 	if err != nil {
-		return map[string]map[string]models.WorktreeNote{}, nil
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]map[string]models.WorktreeNote{}, nil
+		}
+		return nil, err
 	}
 
 	var allNotes map[string]map[string]models.WorktreeNote
@@ -572,36 +595,29 @@ func extractWorktreeNameFromParts(matched, prefix, suffix string) string {
 }
 
 // saveSplittedWorktreeNotes saves individual note files for each worktree.
+// It never removes files for notes absent from the map: the in-memory map may
+// be stale (another process may have created notes since it was loaded), so
+// deletions must only happen explicitly via DeleteSplittedNoteFile.
 func saveSplittedWorktreeNotes(pathTemplate string, notes map[string]models.WorktreeNote, env map[string]string) error {
 	normalized := normalizeWorktreeNotes(notes)
 
-	existingPaths, err := findSplittedNotePaths(pathTemplate, env)
-	if err != nil {
-		return err
-	}
-	for wtName, notePath := range existingPaths {
-		if _, ok := normalized[wtName]; ok {
-			continue
-		}
-		if err := os.Remove(notePath); err != nil && !errors.Is(err, os.ErrNotExist) {
-			return err
-		}
-	}
-
 	// Write each note as an individual file.
 	for wtName, note := range normalized {
-		notePath := ExpandWithEnv(pathTemplate, cloneEnvWith(env, "WORKTREE_NAME", wtName))
-
-		if err := os.MkdirAll(filepath.Dir(notePath), utils.DefaultDirPerms); err != nil {
-			return err
-		}
-		data := FormatNoteFile(note)
-		if err := os.WriteFile(notePath, data, defaultFilePerms); err != nil {
+		if err := writeSplittedNoteFile(pathTemplate, wtName, note, env); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func writeSplittedNoteFile(pathTemplate, wtName string, note models.WorktreeNote, env map[string]string) error {
+	notePath := ExpandWithEnv(pathTemplate, cloneEnvWith(env, "WORKTREE_NAME", wtName))
+
+	if err := os.MkdirAll(filepath.Dir(notePath), utils.DefaultDirPerms); err != nil {
+		return err
+	}
+	return writeAtomically(notePath, FormatNoteFile(note))
 }
 
 // DeleteSplittedNoteFile removes the note file for a specific worktree.

--- a/internal/app/services/persistence_notes_test.go
+++ b/internal/app/services/persistence_notes_test.go
@@ -499,16 +499,18 @@ func TestSplittedWorktreeNotesSavingEmptyNotesSkips(t *testing.T) {
 	}
 }
 
-func TestSplittedWorktreeNotesSaveRemovesStaleFiles(t *testing.T) {
+func TestSplittedWorktreeNotesSavePreservesUnknownFiles(t *testing.T) {
 	baseDir := t.TempDir()
 	pathTemplate := filepath.Join(baseDir, "$WORKTREE_NAME", "note.md")
 	env := map[string]string{}
 
 	require.NoError(t, SaveWorktreeNotes("repo", "", pathTemplate, "splitted", map[string]models.WorktreeNote{
 		"feat-a": {Note: "keep", UpdatedAt: 1},
-		"feat-b": {Note: "remove", UpdatedAt: 1},
+		"feat-b": {Note: "written by another process", UpdatedAt: 1},
 	}, env))
 
+	// A save from a stale in-memory map (missing feat-b) must not delete
+	// feat-b's file: deletions only happen via DeleteSplittedNoteFile.
 	require.NoError(t, SaveWorktreeNotes("repo", "", pathTemplate, "splitted", map[string]models.WorktreeNote{
 		"feat-a": {Note: "keep", UpdatedAt: 2},
 	}, env))
@@ -516,9 +518,102 @@ func TestSplittedWorktreeNotesSaveRemovesStaleFiles(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(baseDir, "feat-a", "note.md")); err != nil {
 		t.Fatalf("expected feat-a note to remain: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(baseDir, "feat-b", "note.md")); !os.IsNotExist(err) {
-		t.Fatalf("expected feat-b note removed, got err=%v", err)
+	if _, err := os.Stat(filepath.Join(baseDir, "feat-b", "note.md")); err != nil {
+		t.Fatalf("expected feat-b note to survive stale save: %v", err)
 	}
+
+	require.NoError(t, DeleteSplittedNoteFile(pathTemplate, "feat-b", env))
+	if _, err := os.Stat(filepath.Join(baseDir, "feat-b", "note.md")); !os.IsNotExist(err) {
+		t.Fatalf("expected feat-b note removed after explicit delete, got err=%v", err)
+	}
+}
+
+func TestSplittedWorktreeNotesSavePreservesUnparseableFiles(t *testing.T) {
+	baseDir := t.TempDir()
+	pathTemplate := filepath.Join(baseDir, "$WORKTREE_NAME", "note.md")
+	env := map[string]string{}
+
+	// Simulate a note file that fails to parse on load (e.g. mid-sync).
+	brokenDir := filepath.Join(baseDir, "feat-broken")
+	require.NoError(t, os.MkdirAll(brokenDir, 0o750))
+	brokenPath := filepath.Join(brokenDir, "note.md")
+	require.NoError(t, os.WriteFile(brokenPath, []byte("---\n: bad frontmatter\n"), 0o600))
+
+	loaded, err := LoadWorktreeNotes("repo", "", pathTemplate, "splitted", env)
+	require.NoError(t, err)
+
+	loaded["feat-new"] = models.WorktreeNote{Note: "hello", UpdatedAt: 1}
+	require.NoError(t, SaveWorktreeNotes("repo", "", pathTemplate, "splitted", loaded, env))
+
+	if _, err := os.Stat(brokenPath); err != nil {
+		t.Fatalf("expected unparseable note file to be preserved: %v", err)
+	}
+}
+
+func TestSaveWorktreeNoteEntrySplitted(t *testing.T) {
+	baseDir := t.TempDir()
+	pathTemplate := filepath.Join(baseDir, "$WORKTREE_NAME", "note.md")
+	env := map[string]string{}
+
+	require.NoError(t, SaveWorktreeNotes("repo", "", pathTemplate, "splitted", map[string]models.WorktreeNote{
+		"feat-other": {Note: "other", UpdatedAt: 1},
+	}, env))
+	otherPath := filepath.Join(baseDir, "feat-other", "note.md")
+	otherBefore, err := os.ReadFile(otherPath) // #nosec G304 -- test-controlled path
+	require.NoError(t, err)
+
+	// Saving a single entry from a map that lacks feat-other must only
+	// touch feat-a's file.
+	notes := map[string]models.WorktreeNote{
+		"feat-a": {Note: "mine", UpdatedAt: 2},
+	}
+	require.NoError(t, SaveWorktreeNoteEntry("repo", "", pathTemplate, "splitted", "feat-a", notes, env))
+
+	if _, err := os.Stat(filepath.Join(baseDir, "feat-a", "note.md")); err != nil {
+		t.Fatalf("expected feat-a note written: %v", err)
+	}
+	otherAfter, err := os.ReadFile(otherPath) // #nosec G304 -- test-controlled path
+	require.NoError(t, err)
+	require.Equal(t, string(otherBefore), string(otherAfter))
+
+	// An absent or empty entry removes only that worktree's file.
+	delete(notes, "feat-a")
+	require.NoError(t, SaveWorktreeNoteEntry("repo", "", pathTemplate, "splitted", "feat-a", notes, env))
+	if _, err := os.Stat(filepath.Join(baseDir, "feat-a", "note.md")); !os.IsNotExist(err) {
+		t.Fatalf("expected feat-a note removed, got err=%v", err)
+	}
+	if _, err := os.Stat(otherPath); err != nil {
+		t.Fatalf("expected feat-other note to remain: %v", err)
+	}
+}
+
+func TestLoadRepoWorktreeNotesPropagatesReadErrors(t *testing.T) {
+	baseDir := t.TempDir()
+	notesPath := filepath.Join(baseDir, "repo", models.WorktreeNotesFilename)
+
+	// Missing file is not an error.
+	notes, err := LoadWorktreeNotes("repo", baseDir, "", "", nil)
+	require.NoError(t, err)
+	require.Empty(t, notes)
+
+	// A directory in place of the file must surface an error rather than
+	// being treated as "no notes" (which a later save would persist).
+	require.NoError(t, os.MkdirAll(notesPath, 0o750))
+	_, err = LoadWorktreeNotes("repo", baseDir, "", "", nil)
+	require.Error(t, err)
+}
+
+func TestLoadSharedWorktreeNotesPropagatesReadErrors(t *testing.T) {
+	baseDir := t.TempDir()
+	sharedPath := filepath.Join(baseDir, "notes.json")
+
+	notes, err := LoadWorktreeNotes("repo", "", sharedPath, "", nil)
+	require.NoError(t, err)
+	require.Empty(t, notes)
+
+	require.NoError(t, os.MkdirAll(sharedPath, 0o750))
+	_, err = LoadWorktreeNotes("repo", "", sharedPath, "", nil)
+	require.Error(t, err)
 }
 
 func TestSplitRepoKey(t *testing.T) {

--- a/internal/app/services/worktree_notes_mutation.go
+++ b/internal/app/services/worktree_notes_mutation.go
@@ -43,5 +43,5 @@ func SaveWorktreeNote(repoKey, worktreeDir, worktreeNotesPath, noteType, worktre
 		// Migrate old full-path keys when switching to shared note storage.
 		delete(notes, trimmedPath)
 	}
-	return SaveWorktreeNotes(repoKey, worktreeDir, worktreeNotesPath, noteType, notes, env)
+	return SaveWorktreeNoteEntry(repoKey, worktreeDir, worktreeNotesPath, noteType, key, notes, env)
 }

--- a/internal/app/worktree_notes.go
+++ b/internal/app/worktree_notes.go
@@ -91,6 +91,25 @@ func (m *Model) saveWorktreeNotes() {
 	}
 }
 
+// saveWorktreeNoteEntry persists only the note identified by key. In splitted
+// mode this touches a single file, so notes created by other processes since
+// the in-memory map was loaded are never rewritten or removed.
+func (m *Model) saveWorktreeNoteEntry(key string) {
+	noteType := m.getWorktreeNoteType()
+	env := m.buildNoteEnv()
+	if err := services.SaveWorktreeNoteEntry(m.getRepoKey(), m.getWorktreeDir(), m.getWorktreeNotesPath(), noteType, key, m.worktreeNotes, env); err != nil {
+		m.debugf("failed to write worktree note: %v", err)
+	}
+}
+
+func (m *Model) deleteSplittedWorktreeNoteFile(key string) bool {
+	if err := services.DeleteSplittedNoteFile(m.getWorktreeNotesPath(), key, m.buildNoteEnv()); err != nil {
+		m.debugf("failed to delete worktree note: %v", err)
+		return false
+	}
+	return true
+}
+
 func (m *Model) getWorktreeNote(path string) (models.WorktreeNote, bool) {
 	if strings.TrimSpace(path) == "" {
 		return models.WorktreeNote{}, false
@@ -132,7 +151,7 @@ func (m *Model) updateWorktreeNoteField(path string, updater func(existing model
 			delete(m.worktreeNotes, filepath.Clean(path))
 		}
 	}
-	m.saveWorktreeNotes()
+	m.saveWorktreeNoteEntry(key)
 	m.refreshSelectedWorktreeNotesPane()
 }
 
@@ -191,11 +210,16 @@ func (m *Model) deleteWorktreeNote(path string) {
 	if _, ok := m.worktreeNotes[key]; !ok {
 		return
 	}
-	delete(m.worktreeNotes, key)
 	if m.getWorktreeNoteType() == config.NoteTypeSplitted {
-		_ = services.DeleteSplittedNoteFile(m.getWorktreeNotesPath(), key, m.buildNoteEnv())
+		if !m.deleteSplittedWorktreeNoteFile(key) {
+			return
+		}
+	} else {
+		delete(m.worktreeNotes, key)
+		m.saveWorktreeNotes()
+		return
 	}
-	m.saveWorktreeNotes()
+	delete(m.worktreeNotes, key)
 }
 
 func (m *Model) migrateWorktreeNote(oldPath, newPath string) {
@@ -208,13 +232,16 @@ func (m *Model) migrateWorktreeNote(oldPath, newPath string) {
 		return
 	}
 
-	delete(m.worktreeNotes, oldKey)
 	if m.getWorktreeNoteType() == config.NoteTypeSplitted {
-		_ = services.DeleteSplittedNoteFile(m.getWorktreeNotesPath(), oldKey, m.buildNoteEnv())
+		if !m.deleteSplittedWorktreeNoteFile(oldKey) {
+			return
+		}
 	}
+	delete(m.worktreeNotes, oldKey)
 	note.UpdatedAt = time.Now().Unix()
-	m.worktreeNotes[m.worktreeNoteKey(newPath)] = note
-	m.saveWorktreeNotes()
+	newKey := m.worktreeNoteKey(newPath)
+	m.worktreeNotes[newKey] = note
+	m.saveWorktreeNoteEntry(newKey)
 }
 
 func (m *Model) hasNoteForSelectedWorktree() bool {
@@ -333,14 +360,16 @@ func (m *Model) pruneStaleWorktreeNotes(worktrees []*models.WorktreeInfo) {
 	changed := false
 	for key := range m.worktreeNotes {
 		if !validPaths[key] {
-			if isSplitted {
-				_ = services.DeleteSplittedNoteFile(m.getWorktreeNotesPath(), key, m.buildNoteEnv())
+			if isSplitted && !m.deleteSplittedWorktreeNoteFile(key) {
+				continue
 			}
 			delete(m.worktreeNotes, key)
 			changed = true
 		}
 	}
-	if changed {
+	// Splitted note files are removed individually above; a full save would
+	// rewrite every file from the in-memory map, clobbering concurrent edits.
+	if changed && !isSplitted {
 		m.saveWorktreeNotes()
 	}
 }

--- a/internal/app/worktree_notes_test.go
+++ b/internal/app/worktree_notes_test.go
@@ -216,6 +216,72 @@ func TestPruneStaleWorktreeNotes(t *testing.T) {
 	}
 }
 
+func TestSplittedWorktreeNoteDeletionFailurePreservesState(t *testing.T) {
+	newModel := func(t *testing.T, key string) *Model {
+		t.Helper()
+		baseDir := t.TempDir()
+		notesPath := filepath.Join(baseDir, "$WORKTREE_NAME", "note.md")
+		notePath := filepath.Join(baseDir, key, "note.md")
+		if err := os.MkdirAll(notePath, 0o750); err != nil {
+			t.Fatalf("create note directory: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(notePath, "child"), []byte("keep directory non-empty"), 0o600); err != nil {
+			t.Fatalf("create note directory child: %v", err)
+		}
+
+		m := NewModel(&config.AppConfig{
+			WorktreeDir:       baseDir,
+			WorktreeNotesPath: notesPath,
+			WorktreeNoteType:  config.NoteTypeSplitted,
+		}, "")
+		m.repoKey = testRepoKey
+		m.worktreeNotes = map[string]models.WorktreeNote{
+			key: {Note: "keep me", UpdatedAt: 1},
+		}
+		return m
+	}
+
+	t.Run("delete", func(t *testing.T) {
+		const key = "feature-delete"
+		m := newModel(t, key)
+
+		m.deleteWorktreeNote(filepath.Join("worktrees", key))
+
+		if _, ok := m.worktreeNotes[key]; !ok {
+			t.Fatal("expected note to remain after file deletion failed")
+		}
+	})
+
+	t.Run("migrate", func(t *testing.T) {
+		const oldKey = "feature-old"
+		const newKey = "feature-new"
+		m := newModel(t, oldKey)
+
+		m.migrateWorktreeNote(
+			filepath.Join("worktrees", oldKey),
+			filepath.Join("worktrees", newKey),
+		)
+
+		if _, ok := m.worktreeNotes[oldKey]; !ok {
+			t.Fatal("expected old note to remain after file deletion failed")
+		}
+		if _, ok := m.worktreeNotes[newKey]; ok {
+			t.Fatal("did not expect new note after old file deletion failed")
+		}
+	})
+
+	t.Run("prune", func(t *testing.T) {
+		const key = "feature-stale"
+		m := newModel(t, key)
+
+		m.pruneStaleWorktreeNotes(nil)
+
+		if _, ok := m.worktreeNotes[key]; !ok {
+			t.Fatal("expected stale note to remain after file deletion failed")
+		}
+	})
+}
+
 func TestShowAnnotateWorktreeOpensTextareaWhenNoNote(t *testing.T) {
 	cfg := &config.AppConfig{WorktreeDir: t.TempDir()}
 	m := NewModel(cfg, "")

--- a/internal/cli/operations.go
+++ b/internal/cli/operations.go
@@ -1198,7 +1198,7 @@ func NoteEdit(ctx context.Context, gitSvc gitService, cfg *config.AppConfig, wor
 		nc.notes[nc.key] = parsed
 	}
 
-	return appservices.SaveWorktreeNotes(nc.repoKey, cfg.WorktreeDir, cfg.WorktreeNotesPath, cfg.WorktreeNoteType, nc.notes, nc.env)
+	return appservices.SaveWorktreeNoteEntry(nc.repoKey, cfg.WorktreeDir, cfg.WorktreeNotesPath, cfg.WorktreeNoteType, nc.key, nc.notes, nc.env)
 }
 
 // editNoteInEditor opens the note in an editor and returns the parsed result.
@@ -1297,5 +1297,5 @@ func NoteSet(ctx context.Context, gitSvc gitService, cfg *config.AppConfig, work
 	}
 	nc.notes[nc.key] = merged
 
-	return appservices.SaveWorktreeNotes(nc.repoKey, cfg.WorktreeDir, cfg.WorktreeNotesPath, cfg.WorktreeNoteType, nc.notes, nc.env)
+	return appservices.SaveWorktreeNoteEntry(nc.repoKey, cfg.WorktreeDir, cfg.WorktreeNotesPath, cfg.WorktreeNoteType, nc.key, nc.notes, nc.env)
 }


### PR DESCRIPTION
Saving split worktree notes previously deleted disk files missing from
the in-memory map. When multiple processes modified notes concurrently,
a stale in-memory state could erase or overwrite external edits.

Updates to split notes were switched to targeted single-file saves
so unmanaged files remain untouched. Automatic file deletion during
batch saves was removed to safeguard concurrent changes, while note
load failures are now correctly reported instead of ignored.

Signed-off-by: Chmouel Boudjnah <chmouel@chmouel.com>
