### PR TITLE
fix(screen): forward pasted text to modal inputs

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -743,6 +743,10 @@ func (m *Model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m.handleKeyMsg(msg)
 
+	case tea.PasteMsg:
+		m.debugf("paste: %d bytes screen=%s filter=%t search=%t", len(msg.Content), m.state.ui.screenManager.Type().String(), m.state.view.ShowingFilter, m.state.view.ShowingSearch)
+		return m.handlePasteMsg(msg)
+
 	case worktreesLoadedMsg, cachedWorktreesMsg, pruneResultMsg, absorbMergeResultMsg:
 		return m.handleWorktreeMessages(msg)
 

--- a/internal/app/app_screens.go
+++ b/internal/app/app_screens.go
@@ -25,7 +25,7 @@ func (m *Model) showInfo(message string, action tea.Cmd) {
 	m.state.ui.screenManager.Push(infoScreen)
 }
 
-func (m *Model) handleScreenKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+func (m *Model) handleScreenKey(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if !m.state.ui.screenManager.IsActive() {
 		return m, nil
 	}

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -6,10 +6,46 @@ import (
 	"github.com/chmouel/lazyworktree/internal/config"
 )
 
+// handlePasteMsg routes bracketed-paste content to the focused text input:
+// a modal screen, the search box, or the filter box. Paste with nothing
+// focused is dropped, like a stray key press.
+func (m *Model) handlePasteMsg(msg tea.PasteMsg) (tea.Model, tea.Cmd) {
+	if m.state.ui.screenManager.IsActive() {
+		return m.handleScreenKey(msg)
+	}
+
+	if m.state.view.ShowingSearch {
+		return m.handleSearchInput(msg)
+	}
+
+	if m.state.view.ShowingFilter {
+		return m.applyFilterInputUpdate(msg)
+	}
+
+	return m, nil
+}
+
+// applyFilterInputUpdate feeds a message into the filter box and reapplies
+// the resulting query to whichever pane is currently being filtered.
+func (m *Model) applyFilterInputUpdate(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	m.state.ui.filterInput, cmd = m.state.ui.filterInput.Update(msg)
+	switch m.state.view.FilterTarget {
+	case filterTargetWorktrees:
+		m.setFilterQuery(filterTargetWorktrees, m.state.ui.filterInput.Value())
+		m.updateTable()
+	case filterTargetStatus, filterTargetGitStatus:
+		m.setFilterQuery(filterTargetGitStatus, m.state.ui.filterInput.Value())
+		m.applyStatusFilter()
+	case filterTargetLog:
+		m.setFilterQuery(filterTargetLog, m.state.ui.filterInput.Value())
+		m.applyLogFilter(false)
+	}
+	return m, cmd
+}
+
 // handleKeyMsg processes keyboard input when not in a modal screen.
 func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	var cmd tea.Cmd
-
 	if m.state.view.ShowingSearch {
 		return m.handleSearchInput(msg)
 	}
@@ -29,28 +65,13 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			if keyStr == keyUp || keyStr == keyDown || keyStr == keyCtrlK || keyStr == keyCtrlJ {
 				return m.handleFilterNavigation(keyStr, false)
 			}
-			m.state.ui.filterInput, cmd = m.state.ui.filterInput.Update(msg)
-			m.setFilterQuery(filterTargetWorktrees, m.state.ui.filterInput.Value())
-			m.updateTable()
-			return m, cmd
-		case filterTargetStatus, filterTargetGitStatus:
+			return m.applyFilterInputUpdate(msg)
+		case filterTargetStatus, filterTargetGitStatus, filterTargetLog:
 			if keyStr == keyEnter || isEscKey(keyStr) || keyStr == keyCtrlC {
 				m.exitFilter()
 				return m, nil
 			}
-			m.state.ui.filterInput, cmd = m.state.ui.filterInput.Update(msg)
-			m.setFilterQuery(filterTargetGitStatus, m.state.ui.filterInput.Value())
-			m.applyStatusFilter()
-			return m, cmd
-		case filterTargetLog:
-			if keyStr == keyEnter || isEscKey(keyStr) || keyStr == keyCtrlC {
-				m.exitFilter()
-				return m, nil
-			}
-			m.state.ui.filterInput, cmd = m.state.ui.filterInput.Update(msg)
-			m.setFilterQuery(filterTargetLog, m.state.ui.filterInput.Value())
-			m.applyLogFilter(false)
-			return m, cmd
+			return m.applyFilterInputUpdate(msg)
 		}
 	}
 

--- a/internal/app/handlers_paste_test.go
+++ b/internal/app/handlers_paste_test.go
@@ -1,0 +1,168 @@
+package app
+
+import (
+	"testing"
+
+	"charm.land/bubbles/v2/viewport"
+	tea "charm.land/bubbletea/v2"
+	appscreen "github.com/chmouel/lazyworktree/internal/app/screen"
+)
+
+func TestHandlePasteMsgFillsFilterInput(t *testing.T) {
+	m := newTestModel(t)
+	m.state.view.ShowingFilter = true
+	m.state.view.FilterTarget = filterTargetWorktrees
+	m.state.ui.filterInput.Focus()
+
+	updated, _ := m.handlePasteMsg(tea.PasteMsg{Content: "pasted-query"})
+	m, ok := updated.(*Model)
+	if !ok {
+		t.Fatalf("expected updated model, got %T", updated)
+	}
+
+	if got := m.state.ui.filterInput.Value(); got != "pasted-query" {
+		t.Fatalf("expected filter input to contain pasted content, got %q", got)
+	}
+	if m.state.services.filter.FilterQuery != "pasted-query" {
+		t.Fatalf("expected filter query to be updated, got %q", m.state.services.filter.FilterQuery)
+	}
+}
+
+func TestHandlePasteMsgFillsSearchInput(t *testing.T) {
+	m := newTestModel(t)
+	m.state.view.ShowingSearch = true
+	m.state.view.SearchTarget = searchTargetWorktrees
+	m.state.ui.filterInput.Focus()
+
+	updated, _ := m.handlePasteMsg(tea.PasteMsg{Content: "pasted-search"})
+	m, ok := updated.(*Model)
+	if !ok {
+		t.Fatalf("expected updated model, got %T", updated)
+	}
+
+	if got := m.state.ui.filterInput.Value(); got != "pasted-search" {
+		t.Fatalf("expected search input to contain pasted content, got %q", got)
+	}
+}
+
+func TestHandlePasteMsgRoutesToActiveScreen(t *testing.T) {
+	m := newTestModel(t)
+	inputScr := appscreen.NewInputScreen("Branch name", "feature/my-branch", "", m.theme, m.config.IconsEnabled())
+	m.state.ui.screenManager.Push(inputScr)
+
+	updated, _ := m.handlePasteMsg(tea.PasteMsg{Content: "feature/pasted-branch"})
+	m, ok := updated.(*Model)
+	if !ok {
+		t.Fatalf("expected updated model, got %T", updated)
+	}
+
+	scr, ok := m.state.ui.screenManager.Current().(*appscreen.InputScreen)
+	if !ok {
+		t.Fatalf("expected input screen to remain active, got %T", m.state.ui.screenManager.Current())
+	}
+	if got := scr.Input.Value(); got != "feature/pasted-branch" {
+		t.Fatalf("expected pasted content in screen input, got %q", got)
+	}
+}
+
+// TestPasteMsgThroughUpdateDispatcherFillsWorktreeFilter drives paste through
+// updateModel to cover the app.go dispatch wiring, not just handlePasteMsg.
+func TestPasteMsgThroughUpdateDispatcherFillsWorktreeFilter(t *testing.T) {
+	m := newTestModel(t)
+	m.state.view.FocusedPane = 0
+
+	updated, _ := m.handleKeyMsg(tea.KeyPressMsg{Code: 'f', Text: "f"})
+	updatedModel, ok := updated.(*Model)
+	if !ok {
+		t.Fatalf("expected updated model, got %T", updated)
+	}
+	m = updatedModel
+
+	updated, _ = m.Update(tea.PasteMsg{Content: "pasted-query"})
+	m, ok = updated.(*Model)
+	if !ok {
+		t.Fatalf("expected updated model, got %T", updated)
+	}
+
+	if got := m.state.ui.filterInput.Value(); got != "pasted-query" {
+		t.Fatalf("expected filter input to contain pasted content, got %q", got)
+	}
+	if m.state.services.filter.FilterQuery != "pasted-query" {
+		t.Fatalf("expected filter query to be updated, got %q", m.state.services.filter.FilterQuery)
+	}
+}
+
+func TestHandlePasteMsgNarrowsStatusFilter(t *testing.T) {
+	m := newTestModel(t)
+	m.state.view.FocusedPane = 2
+	m.state.ui.statusViewport = viewport.New(viewport.WithWidth(40), viewport.WithHeight(10))
+	m.setStatusFiles([]StatusFile{
+		{Filename: "app.go", Status: ".M"},
+		{Filename: testReadme, Status: ".M"},
+	})
+
+	updated, _ := m.handleKeyMsg(tea.KeyPressMsg{Code: 'f', Text: "f"})
+	updatedModel, ok := updated.(*Model)
+	if !ok {
+		t.Fatalf("expected updated model, got %T", updated)
+	}
+	m = updatedModel
+
+	updated, _ = m.handlePasteMsg(tea.PasteMsg{Content: "read"})
+	m, ok = updated.(*Model)
+	if !ok {
+		t.Fatalf("expected updated model, got %T", updated)
+	}
+
+	if len(m.state.data.statusFiles) != 1 {
+		t.Fatalf("expected 1 filtered status file, got %d", len(m.state.data.statusFiles))
+	}
+	if m.state.data.statusFiles[0].Filename != testReadme {
+		t.Fatalf("expected %s, got %q", testReadme, m.state.data.statusFiles[0].Filename)
+	}
+}
+
+func TestHandlePasteMsgNarrowsLogFilter(t *testing.T) {
+	m := newTestModel(t)
+	m.state.view.FocusedPane = 3
+	m.setLogEntries([]commitLogEntry{
+		{sha: "abc123", authorInitials: "ab", message: "Fix bug in parser"},
+		{sha: "def456", authorInitials: "de", message: "Add new feature"},
+	}, false)
+
+	updated, _ := m.handleKeyMsg(tea.KeyPressMsg{Code: 'f', Text: "f"})
+	updatedModel, ok := updated.(*Model)
+	if !ok {
+		t.Fatalf("expected updated model, got %T", updated)
+	}
+	m = updatedModel
+
+	updated, _ = m.handlePasteMsg(tea.PasteMsg{Content: "fix"})
+	m, ok = updated.(*Model)
+	if !ok {
+		t.Fatalf("expected updated model, got %T", updated)
+	}
+
+	if len(m.state.data.logEntries) != 1 {
+		t.Fatalf("expected 1 filtered commit, got %d", len(m.state.data.logEntries))
+	}
+	if m.state.data.logEntries[0].sha != "abc123" {
+		t.Fatalf("expected commit abc123, got %q", m.state.data.logEntries[0].sha)
+	}
+}
+
+func TestHandlePasteMsgIgnoredWhenNothingFocused(t *testing.T) {
+	m := newTestModel(t)
+
+	updated, cmd := m.handlePasteMsg(tea.PasteMsg{Content: "stray paste"})
+	m, ok := updated.(*Model)
+	if !ok {
+		t.Fatalf("expected updated model, got %T", updated)
+	}
+	if cmd != nil {
+		t.Fatal("expected no command when nothing is focused")
+	}
+	if m.state.ui.filterInput.Value() != "" {
+		t.Fatalf("expected filter input to remain empty, got %q", m.state.ui.filterInput.Value())
+	}
+}

--- a/internal/app/handlers_search.go
+++ b/internal/app/handlers_search.go
@@ -32,20 +32,23 @@ func (m *Model) handleSearchKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd, bool) 
 	}
 }
 
-func (m *Model) handleSearchInput(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	keyStr := msg.String()
-	if keyStr == keyEnter {
-		m.state.view.ShowingSearch = false
-		m.state.ui.filterInput.Blur()
-		m.restoreFocusAfterSearch()
-		return m, nil
-	}
-	if isEscKey(keyStr) || keyStr == keyCtrlC {
-		m.clearSearchQuery()
-		m.state.view.ShowingSearch = false
-		m.state.ui.filterInput.Blur()
-		m.restoreFocusAfterSearch()
-		return m, nil
+// handleSearchInput feeds a key press or pasted text into the search box.
+func (m *Model) handleSearchInput(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if keyMsg, ok := msg.(tea.KeyPressMsg); ok {
+		keyStr := keyMsg.String()
+		if keyStr == keyEnter {
+			m.state.view.ShowingSearch = false
+			m.state.ui.filterInput.Blur()
+			m.restoreFocusAfterSearch()
+			return m, nil
+		}
+		if isEscKey(keyStr) || keyStr == keyCtrlC {
+			m.clearSearchQuery()
+			m.state.view.ShowingSearch = false
+			m.state.ui.filterInput.Blur()
+			m.restoreFocusAfterSearch()
+			return m, nil
+		}
 	}
 
 	var cmd tea.Cmd

--- a/internal/app/screen/checklist.go
+++ b/internal/app/screen/checklist.go
@@ -97,8 +97,18 @@ func (s *ChecklistScreen) Type() Type {
 
 // Update handles keyboard input for the checklist screen.
 // Returns nil to signal the screen should close.
-func (s *ChecklistScreen) Update(msg tea.KeyPressMsg) (Screen, tea.Cmd) {
+func (s *ChecklistScreen) Update(raw tea.Msg) (Screen, tea.Cmd) {
 	var cmd tea.Cmd
+
+	msg, ok := raw.(tea.KeyPressMsg)
+	if !ok {
+		if s.FilterActive {
+			s.FilterInput, cmd = s.FilterInput.Update(raw)
+			s.applyFilter()
+			return s, cmd
+		}
+		return s, nil
+	}
 	maxVisibleLines := s.Height - 6
 	if !s.FilterActive {
 		maxVisibleLines += 2

--- a/internal/app/screen/commit.go
+++ b/internal/app/screen/commit.go
@@ -54,7 +54,11 @@ func (s *CommitScreen) Type() Type {
 
 // Update handles scrolling and closing events for the commit screen.
 // Returns nil to signal that the screen should be closed.
-func (s *CommitScreen) Update(msg tea.KeyPressMsg) (Screen, tea.Cmd) {
+func (s *CommitScreen) Update(raw tea.Msg) (Screen, tea.Cmd) {
+	msg, ok := raw.(tea.KeyPressMsg)
+	if !ok {
+		return s, nil
+	}
 	switch msg.String() {
 	case keyQ, keyEsc, keyEscRaw, keyCtrlC:
 		return nil, nil

--- a/internal/app/screen/commit_files.go
+++ b/internal/app/screen/commit_files.go
@@ -315,7 +315,30 @@ func (s *CommitFilesScreen) ToggleCollapse(path string) {
 }
 
 // Update handles key events for the commit files screen.
-func (s *CommitFilesScreen) Update(msg tea.KeyPressMsg) (Screen, tea.Cmd) {
+func (s *CommitFilesScreen) Update(raw tea.Msg) (Screen, tea.Cmd) {
+	msg, ok := raw.(tea.KeyPressMsg)
+	if !ok {
+		var cmd tea.Cmd
+		switch {
+		case s.ShowingFilter:
+			s.FilterInput, cmd = s.FilterInput.Update(raw)
+			newQuery := s.FilterInput.Value()
+			if newQuery != s.FilterQuery {
+				s.FilterQuery = newQuery
+				s.ApplyFilter()
+			}
+		case s.ShowingSearch:
+			s.FilterInput, cmd = s.FilterInput.Update(raw)
+			newQuery := s.FilterInput.Value()
+			if newQuery != s.SearchQuery {
+				s.SearchQuery = newQuery
+				if s.SearchQuery != "" {
+					s.SearchNext(true)
+				}
+			}
+		}
+		return s, cmd
+	}
 	maxVisible := s.Height - 8 // Account for header, footer, borders
 	keyStr := msg.String()
 

--- a/internal/app/screen/commit_message.go
+++ b/internal/app/screen/commit_message.go
@@ -120,67 +120,68 @@ func (s *CommitMessageScreen) Type() Type {
 	return TypeCommitMessage
 }
 
-// Update handles keyboard input for the commit message screen.
-func (s *CommitMessageScreen) Update(msg tea.KeyPressMsg) (Screen, tea.Cmd) {
+// Update handles keyboard input and pasted text for the commit message screen.
+func (s *CommitMessageScreen) Update(raw tea.Msg) (Screen, tea.Cmd) {
 	var cmd tea.Cmd
-	keyStr := msg.String()
 
-	switch keyStr {
-	case keyTab, keyShiftTab:
-		s.toggleFocus()
-		return s, nil
-
-	case keyEnter:
-		if s.focus == commitMessageFocusSubject {
-			s.focus = commitMessageFocusBody
-			s.syncFocus()
+	if msg, ok := raw.(tea.KeyPressMsg); ok {
+		switch msg.String() {
+		case keyTab, keyShiftTab:
+			s.toggleFocus()
 			return s, nil
-		}
 
-	case "ctrl+s":
-		value := s.Value()
-		if strings.TrimSpace(s.SubjectInput.Value()) == "" {
-			s.ErrorMsg = "Commit subject cannot be empty."
-			return s, nil
-		}
-		if s.Validate != nil {
-			if errMsg := strings.TrimSpace(s.Validate(value)); errMsg != "" {
-				s.ErrorMsg = errMsg
+		case keyEnter:
+			if s.focus == commitMessageFocusSubject {
+				s.focus = commitMessageFocusBody
+				s.syncFocus()
 				return s, nil
 			}
-		}
-		s.ErrorMsg = ""
-		if s.OnSubmit != nil {
-			cmd = s.OnSubmit(value)
-			if s.ErrorMsg != "" {
-				return s, cmd
+
+		case "ctrl+s":
+			value := s.Value()
+			if strings.TrimSpace(s.SubjectInput.Value()) == "" {
+				s.ErrorMsg = "Commit subject cannot be empty."
+				return s, nil
 			}
-		}
-		return nil, cmd
-
-	case "ctrl+o":
-		if s.HasAutoGenerate && s.OnAutoGenerate != nil {
-			return s, s.OnAutoGenerate()
-		}
-
-	case "ctrl+x":
-		if s.OnEditExternal != nil {
+			if s.Validate != nil {
+				if errMsg := strings.TrimSpace(s.Validate(value)); errMsg != "" {
+					s.ErrorMsg = errMsg
+					return s, nil
+				}
+			}
 			s.ErrorMsg = ""
-			return s, s.OnEditExternal(s.Value())
-		}
-		return s, nil
+			if s.OnSubmit != nil {
+				cmd = s.OnSubmit(value)
+				if s.ErrorMsg != "" {
+					return s, cmd
+				}
+			}
+			return nil, cmd
 
-	case keyEsc, keyCtrlC:
-		if s.OnCancel != nil {
-			return nil, s.OnCancel()
+		case "ctrl+o":
+			if s.HasAutoGenerate && s.OnAutoGenerate != nil {
+				return s, s.OnAutoGenerate()
+			}
+
+		case "ctrl+x":
+			if s.OnEditExternal != nil {
+				s.ErrorMsg = ""
+				return s, s.OnEditExternal(s.Value())
+			}
+			return s, nil
+
+		case keyEsc, keyCtrlC:
+			if s.OnCancel != nil {
+				return nil, s.OnCancel()
+			}
+			return nil, nil
 		}
-		return nil, nil
 	}
 
 	if s.focus == commitMessageFocusSubject {
-		s.SubjectInput, cmd = s.SubjectInput.Update(msg)
+		s.SubjectInput, cmd = s.SubjectInput.Update(raw)
 	} else {
-		s.BodyInput, cmd = s.BodyInput.Update(msg)
+		s.BodyInput, cmd = s.BodyInput.Update(raw)
 	}
 	s.applySubjectStyles()
 	return s, cmd

--- a/internal/app/screen/commit_message_test.go
+++ b/internal/app/screen/commit_message_test.go
@@ -77,6 +77,41 @@ func TestCommitMessageScreenEnterMovesFocusToBody(t *testing.T) {
 	}
 }
 
+func TestCommitMessageScreenPasteGoesToSubjectByDefault(t *testing.T) {
+	s := NewCommitMessageScreen("Commit", "Body", "", 120, 40, theme.Dracula(), false, false)
+
+	next, _ := s.Update(tea.PasteMsg{Content: "pasted subject"})
+	updated, ok := next.(*CommitMessageScreen)
+	if !ok || updated == nil {
+		t.Fatal("expected commit message screen after paste")
+	}
+	if got := updated.SubjectInput.Value(); got != "pasted subject" {
+		t.Fatalf("expected pasted content in subject, got %q", got)
+	}
+	if updated.BodyInput.Value() != "" {
+		t.Fatalf("expected body to stay empty, got %q", updated.BodyInput.Value())
+	}
+}
+
+func TestCommitMessageScreenPasteGoesToBodyAfterFocusMoves(t *testing.T) {
+	s := NewCommitMessageScreen("Commit", "Body", "", 120, 40, theme.Dracula(), false, false)
+
+	next, _ := s.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	updated := next.(*CommitMessageScreen)
+
+	next, _ = updated.Update(tea.PasteMsg{Content: "pasted body"})
+	updated, ok := next.(*CommitMessageScreen)
+	if !ok || updated == nil {
+		t.Fatal("expected commit message screen after paste")
+	}
+	if got := updated.BodyInput.Value(); got != "pasted body" {
+		t.Fatalf("expected pasted content in body, got %q", got)
+	}
+	if updated.SubjectInput.Value() != "" {
+		t.Fatalf("expected subject to stay empty, got %q", updated.SubjectInput.Value())
+	}
+}
+
 func TestCommitMessageScreenCtrlXEditExternal(t *testing.T) {
 	s := NewCommitMessageScreen("Commit", "Body", "subject\n\nbody", 120, 40, theme.Dracula(), false, false)
 	called := false

--- a/internal/app/screen/confirm.go
+++ b/internal/app/screen/confirm.go
@@ -55,7 +55,11 @@ func (s *ConfirmScreen) Type() Type {
 
 // Update processes keyboard events for the confirmation dialog.
 // Returns nil to signal that the screen should be closed.
-func (s *ConfirmScreen) Update(msg tea.KeyPressMsg) (Screen, tea.Cmd) {
+func (s *ConfirmScreen) Update(raw tea.Msg) (Screen, tea.Cmd) {
+	msg, ok := raw.(tea.KeyPressMsg)
+	if !ok {
+		return s, nil
+	}
 	key := msg.String()
 	switch key {
 	case keyTab, "right", "l":

--- a/internal/app/screen/help.go
+++ b/internal/app/screen/help.go
@@ -403,8 +403,22 @@ func (s *HelpScreen) Type() Type {
 }
 
 // Update handles scrolling and search input for the help screen.
-func (s *HelpScreen) Update(msg tea.KeyPressMsg) (Screen, tea.Cmd) {
+func (s *HelpScreen) Update(raw tea.Msg) (Screen, tea.Cmd) {
 	var cmd tea.Cmd
+
+	msg, ok := raw.(tea.KeyPressMsg)
+	if !ok {
+		if s.Searching {
+			s.SearchInput, cmd = s.SearchInput.Update(raw)
+			newQuery := strings.TrimSpace(s.SearchInput.Value())
+			if newQuery != s.SearchQuery {
+				s.SearchQuery = newQuery
+				s.refreshContent()
+			}
+			return s, cmd
+		}
+		return s, nil
+	}
 	key := msg.String()
 
 	switch key {

--- a/internal/app/screen/info.go
+++ b/internal/app/screen/info.go
@@ -32,7 +32,11 @@ func (s *InfoScreen) Type() Type {
 
 // Update processes keyboard events for the info dialog.
 // Returns nil to signal that the screen should be closed.
-func (s *InfoScreen) Update(msg tea.KeyPressMsg) (Screen, tea.Cmd) {
+func (s *InfoScreen) Update(raw tea.Msg) (Screen, tea.Cmd) {
+	msg, ok := raw.(tea.KeyPressMsg)
+	if !ok {
+		return s, nil
+	}
 	switch msg.String() {
 	case keyEnter, keyEsc, keyQ, keyCtrlC:
 		if s.OnClose != nil {

--- a/internal/app/screen/input.go
+++ b/internal/app/screen/input.go
@@ -100,10 +100,21 @@ func (s *InputScreen) Type() Type {
 	return TypeInput
 }
 
-// Update handles keyboard input for the input screen.
+// Update handles keyboard input and pasted text for the input screen.
 // Returns nil to signal the screen should be closed.
-func (s *InputScreen) Update(msg tea.KeyPressMsg) (Screen, tea.Cmd) {
+func (s *InputScreen) Update(raw tea.Msg) (Screen, tea.Cmd) {
 	var cmd tea.Cmd
+
+	msg, ok := raw.(tea.KeyPressMsg)
+	if !ok {
+		if s.CheckboxEnabled && s.CheckboxFocused {
+			return s, nil
+		}
+		// Pasting exits history browsing, same as typing a character.
+		s.HistoryIndex = -1
+		s.Input, cmd = s.Input.Update(raw)
+		return s, cmd
+	}
 	keyStr := msg.String()
 
 	switch keyStr {
@@ -193,6 +204,10 @@ func (s *InputScreen) Update(msg tea.KeyPressMsg) (Screen, tea.Cmd) {
 			}
 			return s, nil
 		}
+	}
+
+	if s.CheckboxEnabled && s.CheckboxFocused {
+		return s, nil
 	}
 
 	// Reset history browsing when user types

--- a/internal/app/screen/input_test.go
+++ b/internal/app/screen/input_test.go
@@ -1,0 +1,69 @@
+package screen
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/chmouel/lazyworktree/internal/theme"
+)
+
+func TestInputScreenPasteInsertsContent(t *testing.T) {
+	scr := NewInputScreen("Branch name", "feature/my-branch", "", theme.Dracula(), false)
+
+	next, cmd := scr.Update(tea.PasteMsg{Content: "feature/pasted-branch"})
+	require.NotNil(t, next)
+	inputScr, ok := next.(*InputScreen)
+	require.True(t, ok)
+	require.Equal(t, "feature/pasted-branch", inputScr.Input.Value())
+	_ = cmd
+}
+
+func TestInputScreenPasteInsertsAtCursor(t *testing.T) {
+	scr := NewInputScreen("Branch name", "feature/my-branch", "feature/", theme.Dracula(), false)
+	scr.Input.CursorEnd()
+
+	next, _ := scr.Update(tea.PasteMsg{Content: "pasted"})
+	inputScr, ok := next.(*InputScreen)
+	require.True(t, ok)
+	require.Equal(t, "feature/pasted", inputScr.Input.Value())
+}
+
+func TestInputScreenPasteResetsHistoryBrowsing(t *testing.T) {
+	scr := NewInputScreen("Run command", "e.g. make test", "", theme.Dracula(), false)
+	scr.SetHistory([]string{"make build", "make test"})
+
+	next, _ := scr.Update(tea.KeyPressMsg{Code: tea.KeyUp})
+	inputScr, ok := next.(*InputScreen)
+	require.True(t, ok)
+	require.Equal(t, 0, inputScr.HistoryIndex)
+
+	next, _ = inputScr.Update(tea.PasteMsg{Content: "pasted command"})
+	inputScr, ok = next.(*InputScreen)
+	require.True(t, ok)
+	require.Equal(t, -1, inputScr.HistoryIndex)
+}
+
+func TestInputScreenPasteIgnoredWhenCheckboxFocused(t *testing.T) {
+	scr := NewInputScreen("Create from current", "feature/my-branch", "generated-name", theme.Dracula(), false)
+	scr.SetCheckbox("Include current file changes", true)
+	scr.CheckboxFocused = true
+
+	next, _ := scr.Update(tea.PasteMsg{Content: "pasted-branch-name"})
+	inputScr, ok := next.(*InputScreen)
+	require.True(t, ok)
+	require.Equal(t, "generated-name", inputScr.Input.Value())
+	require.True(t, inputScr.CheckboxFocused)
+}
+
+func TestInputScreenTypingIgnoredWhenCheckboxFocused(t *testing.T) {
+	scr := NewInputScreen("Create from current", "feature/my-branch", "generated-name", theme.Dracula(), false)
+	scr.SetCheckbox("Include current file changes", true)
+	scr.CheckboxFocused = true
+
+	next, _ := scr.Update(tea.KeyPressMsg{Code: 'x', Text: "x"})
+	inputScr, ok := next.(*InputScreen)
+	require.True(t, ok)
+	require.Equal(t, "generated-name", inputScr.Input.Value())
+}

--- a/internal/app/screen/list_select.go
+++ b/internal/app/screen/list_select.go
@@ -127,8 +127,18 @@ func (s *ListSelectionScreen) Type() Type {
 }
 
 // Update handles keyboard input and returns nil to signal the screen should close.
-func (s *ListSelectionScreen) Update(msg tea.KeyPressMsg) (Screen, tea.Cmd) {
+func (s *ListSelectionScreen) Update(raw tea.Msg) (Screen, tea.Cmd) {
 	var cmd tea.Cmd
+
+	msg, ok := raw.(tea.KeyPressMsg)
+	if !ok {
+		if s.FilterActive {
+			s.FilterInput, cmd = s.FilterInput.Update(raw)
+			s.applyFilter()
+			return s, cmd
+		}
+		return s, nil
+	}
 	maxVisible := s.maxVisible()
 	keyStr := msg.String()
 

--- a/internal/app/screen/loading.go
+++ b/internal/app/screen/loading.go
@@ -207,7 +207,7 @@ func (s *LoadingScreen) Type() Type {
 }
 
 // Update handles key events. Loading screen does not respond to keys.
-func (s *LoadingScreen) Update(msg tea.KeyPressMsg) (Screen, tea.Cmd) {
+func (s *LoadingScreen) Update(msg tea.Msg) (Screen, tea.Cmd) {
 	// Loading screen ignores key input
 	return s, nil
 }

--- a/internal/app/screen/note_view.go
+++ b/internal/app/screen/note_view.go
@@ -60,7 +60,11 @@ func (s *NoteViewScreen) Resize(maxWidth, maxHeight int) {
 }
 
 // Update handles navigation, close, and edit actions.
-func (s *NoteViewScreen) Update(msg tea.KeyPressMsg) (Screen, tea.Cmd) {
+func (s *NoteViewScreen) Update(raw tea.Msg) (Screen, tea.Cmd) {
+	msg, ok := raw.(tea.KeyPressMsg)
+	if !ok {
+		return s, nil
+	}
 	switch msg.String() {
 	case keyQ, keyEsc, keyEscRaw, keyCtrlC:
 		if s.OnClose != nil {

--- a/internal/app/screen/palette.go
+++ b/internal/app/screen/palette.go
@@ -131,8 +131,19 @@ func (s *CommandPaletteScreen) Type() Type {
 }
 
 // Update handles keyboard input for the command palette.
-func (s *CommandPaletteScreen) Update(msg tea.KeyPressMsg) (Screen, tea.Cmd) {
+func (s *CommandPaletteScreen) Update(raw tea.Msg) (Screen, tea.Cmd) {
 	const maxVisible = 12
+
+	msg, ok := raw.(tea.KeyPressMsg)
+	if !ok {
+		if s.FilterActive {
+			var cmd tea.Cmd
+			s.FilterInput, cmd = s.FilterInput.Update(raw)
+			s.applyFilter()
+			return s, cmd
+		}
+		return s, nil
+	}
 	keyStr := msg.String()
 
 	if !s.FilterActive {

--- a/internal/app/screen/pr_select.go
+++ b/internal/app/screen/pr_select.go
@@ -81,9 +81,9 @@ func (s *PRSelectionScreen) Type() Type {
 }
 
 // Update handles updates for the PR selection screen.
-func (s *PRSelectionScreen) Update(msg tea.KeyPressMsg) (Screen, tea.Cmd) {
+func (s *PRSelectionScreen) Update(msg tea.Msg) (Screen, tea.Cmd) {
 	// PR screen accepts 'q' as quit in both filtered and unfiltered modes
-	if msg.String() == keyQ {
+	if keyMsg, ok := msg.(tea.KeyPressMsg); ok && keyMsg.String() == keyQ {
 		if s.OnCancel != nil {
 			return nil, s.OnCancel()
 		}

--- a/internal/app/screen/screen.go
+++ b/internal/app/screen/screen.go
@@ -7,9 +7,10 @@ import (
 
 // Screen represents a modal screen overlay that can handle input and render itself.
 type Screen interface {
-	// Update processes a key message and returns the updated screen and any command.
-	// Returning nil for the Screen signals that this screen should be closed.
-	Update(msg tea.KeyPressMsg) (Screen, tea.Cmd)
+	// Update processes a key press or paste message and returns the updated
+	// screen and any command. Returning nil for the Screen signals that this
+	// screen should be closed.
+	Update(msg tea.Msg) (Screen, tea.Cmd)
 
 	// View renders the screen's content.
 	View() string

--- a/internal/app/screen/tag_editor.go
+++ b/internal/app/screen/tag_editor.go
@@ -92,8 +92,18 @@ func (s *TagEditorScreen) Type() Type {
 	return TypeTagEditor
 }
 
-// Update handles keyboard input for the tag editor.
-func (s *TagEditorScreen) Update(msg tea.KeyPressMsg) (Screen, tea.Cmd) {
+// Update handles keyboard input and pasted text for the tag editor.
+func (s *TagEditorScreen) Update(raw tea.Msg) (Screen, tea.Cmd) {
+	msg, ok := raw.(tea.KeyPressMsg)
+	if !ok {
+		if s.focus != tagEditorFocusList {
+			var cmd tea.Cmd
+			s.Input, cmd = s.Input.Update(raw)
+			s.ErrorMsg = ""
+			return s, cmd
+		}
+		return s, nil
+	}
 	keyStr := msg.String()
 
 	switch keyStr {

--- a/internal/app/screen/tag_editor_test.go
+++ b/internal/app/screen/tag_editor_test.go
@@ -74,3 +74,52 @@ func TestTagEditorScreenEnterSubmitsCurrentTags(t *testing.T) {
 		t.Fatalf("unexpected submitted tags: %q", got)
 	}
 }
+
+func TestTagEditorScreenPasteGoesToFocusedInput(t *testing.T) {
+	scr := NewTagEditorScreen(
+		"Set worktree tags",
+		nil,
+		[]TagEditorOption{{Tag: "bug", Count: 2}},
+		120,
+		40,
+		theme.Dracula(),
+		false,
+	)
+
+	// Input is focused by default.
+	next, _ := scr.Update(tea.PasteMsg{Content: "pasted-tag"})
+	tagScr, ok := next.(*TagEditorScreen)
+	if !ok || tagScr == nil {
+		t.Fatal("expected tag editor screen after paste")
+	}
+	if got := tagScr.Input.Value(); got != "pasted-tag" {
+		t.Fatalf("expected pasted content in input, got %q", got)
+	}
+}
+
+func TestTagEditorScreenPasteIgnoredWhenListFocused(t *testing.T) {
+	scr := NewTagEditorScreen(
+		"Set worktree tags",
+		nil,
+		[]TagEditorOption{{Tag: "bug", Count: 2}},
+		120,
+		40,
+		theme.Dracula(),
+		false,
+	)
+
+	next, _ := scr.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	tagScr, ok := next.(*TagEditorScreen)
+	if !ok || tagScr == nil {
+		t.Fatal("expected tag editor screen after Tab")
+	}
+
+	next, _ = tagScr.Update(tea.PasteMsg{Content: "pasted-tag"})
+	tagScr, ok = next.(*TagEditorScreen)
+	if !ok || tagScr == nil {
+		t.Fatal("expected tag editor screen after paste")
+	}
+	if got := tagScr.Input.Value(); got != "" {
+		t.Fatalf("expected paste to be ignored while list is focused, got %q", got)
+	}
+}

--- a/internal/app/screen/taskboard.go
+++ b/internal/app/screen/taskboard.go
@@ -111,8 +111,19 @@ func (s *TaskboardScreen) SetItems(items []TaskboardItem, preferredID string) {
 }
 
 // Update handles keyboard input.
-func (s *TaskboardScreen) Update(msg tea.KeyPressMsg) (Screen, tea.Cmd) {
+func (s *TaskboardScreen) Update(raw tea.Msg) (Screen, tea.Cmd) {
 	var cmd tea.Cmd
+
+	msg, ok := raw.(tea.KeyPressMsg)
+	if !ok {
+		if s.FilterActive {
+			s.FilterInput, cmd = s.FilterInput.Update(raw)
+			s.applyFilter()
+			s.ensureCursorVisible()
+			return s, cmd
+		}
+		return s, nil
+	}
 	keyStr := msg.String()
 
 	if !s.FilterActive {

--- a/internal/app/screen/textarea.go
+++ b/internal/app/screen/textarea.go
@@ -85,10 +85,16 @@ func (s *TextareaScreen) Type() Type {
 	return TypeTextarea
 }
 
-// Update handles keyboard input for the textarea screen.
+// Update handles keyboard input and pasted text for the textarea screen.
 // Returns nil to signal the screen should be closed.
-func (s *TextareaScreen) Update(msg tea.KeyPressMsg) (Screen, tea.Cmd) {
+func (s *TextareaScreen) Update(raw tea.Msg) (Screen, tea.Cmd) {
 	var cmd tea.Cmd
+
+	msg, ok := raw.(tea.KeyPressMsg)
+	if !ok {
+		s.Input, cmd = s.Input.Update(raw)
+		return s, cmd
+	}
 	keyStr := msg.String()
 
 	switch keyStr {

--- a/internal/app/screen/trust.go
+++ b/internal/app/screen/trust.go
@@ -48,7 +48,11 @@ func (s *TrustScreen) Type() Type {
 
 // Update handles trust decisions and delegates viewport input updates.
 // Returns nil to signal that the screen should be closed.
-func (s *TrustScreen) Update(msg tea.KeyPressMsg) (Screen, tea.Cmd) {
+func (s *TrustScreen) Update(raw tea.Msg) (Screen, tea.Cmd) {
+	msg, ok := raw.(tea.KeyPressMsg)
+	if !ok {
+		return s, nil
+	}
 	keyStr := msg.String()
 	switch keyStr {
 	case "t", "T":

--- a/internal/app/screen/welcome.go
+++ b/internal/app/screen/welcome.go
@@ -35,7 +35,11 @@ func (s *WelcomeScreen) Type() Type {
 
 // Update processes keyboard events for the welcome screen.
 // Returns nil to signal that the screen should be closed.
-func (s *WelcomeScreen) Update(msg tea.KeyPressMsg) (Screen, tea.Cmd) {
+func (s *WelcomeScreen) Update(raw tea.Msg) (Screen, tea.Cmd) {
+	msg, ok := raw.(tea.KeyPressMsg)
+	if !ok {
+		return s, nil
+	}
 	keyStr := msg.String()
 	switch keyStr {
 	case "r", "R":


### PR DESCRIPTION
# Description

Bracketed paste (e.g. into the "create worktree from branch" branch-name dialog) was silently dropped: bubbletea v2 delivers pasted text as a distinct `tea.PasteMsg`, separate from `tea.KeyPressMsg`, but the `Screen` interface and the app's top-level `Update` dispatcher only ever handled `tea.KeyPressMsg`. Pasted content never reached any modal input, or the worktree filter/search box.

Fixes this by:
- Widening `Screen.Update` (`internal/app/screen/screen.go`) from `tea.KeyPressMsg` to `tea.Msg`.
- Updating all 18 `Screen` implementations to route `tea.PasteMsg` content to whichever text field currently has focus (and to ignore paste when no text field is focused, e.g. a list-only screen or an unfocused filter).
- Adding a `tea.PasteMsg` case to the app's `updateModel` dispatcher (`internal/app/app.go`) and a new `handlePasteMsg` (`internal/app/handlers.go`) that routes paste to the active modal screen, the search box, or the filter box.

Ran `/simplify` on the diff afterward, which deduped the filter/search update-and-apply logic between the key-press and paste code paths (`internal/app/handlers.go:applyFilterInputUpdate`, widened `handleSearchInput` to `tea.Msg`) and removed a redundant paste-guard in `commit_message.go` that duplicated the screen's existing focus-routing tail verbatim.

An automated review (Qodo) then flagged that `InputScreen` forwarded paste (and, pre-existing, plain keypresses) into the text field even while a checkbox had focus — able to silently overwrite a generated branch name mid-toggle in the "create from current" flow. Fixed by guarding both paths on `CheckboxFocused`, with regression tests added.

## Tests

- Added unit tests covering paste behaviour and focus-routing:
  - `internal/app/screen/input_test.go` (new) — paste inserts at cursor, exits history-browsing mode, and is ignored while the checkbox has focus (plus a matching keypress regression test).
  - `internal/app/screen/tag_editor_test.go` — paste goes to the text input when focused, is ignored when the tag list is focused.
  - `internal/app/screen/commit_message_test.go` — paste routes to whichever of subject/body currently has focus.
  - `internal/app/handlers_paste_test.go` (new) — `handlePasteMsg` fills the top-level filter box (worktree, status, and log targets), the search box, and forwards to an active modal screen; a no-op when nothing is focused. Includes a dispatcher-level test going through the real `m.Update(tea.PasteMsg{...})` path, not just `handlePasteMsg` directly.
- `make sanity` (lint + gofumpt + full test suite) passes clean.
- Manually verified end-to-end in a real terminal and via a scripted `tmux paste-buffer` bracketed-paste simulation: built the binary, walked `c` → "Pick a base branch or tag" → select branch → the exact "Create worktree: branch name" dialog from the bug report, pasted a branch name, confirmed it appeared correctly, confirmed normal typing/Esc/Enter still work, and confirmed the top-level `f` filter box and a `ListSelectionScreen`'s in-screen filter both accept paste too.

---

_This contribution was authored by an AI agent (Claude Code, claude-sonnet-5) on behalf of the contributor._