### PR TITLE
Protect uncommitted worktrees during cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ _[You can see more screenshots here](https://chmouel.github.io/lazyworktree/#scr
 
 ## Main Features
 
-- Worktree management - Create worktrees from branches, PRs/MRs, or issues; clean up, delete, list, and switch between them
+- Worktree management - Create worktrees from branches, PRs/MRs, or issues; safely clean up merged worktrees without discarding uncommitted changes; delete, list, and switch between them
 - CI & PR/MR status - See GitHub Actions and GitLab CI results, check PR/MR details, view logs and more.
 - Agent sessions pane - See confirmed active Claude, Codex, Copilot, and pi sessions attached to the selected worktree.
 - Command palette - Quick access to all actions and custom commands with `?`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -115,16 +115,18 @@ During rename, the branch is renamed only if the current worktree directory name
 
 ```bash
 lazyworktree cleanup              # Choose candidates from a numbered menu
-lazyworktree cleanup --all        # Remove every candidate without prompting
+lazyworktree cleanup --all        # Attempt every candidate without prompting
 lazyworktree cleanup --all --json # Emit the result as JSON
 ```
 
-The interactive menu accepts comma-separated numbers and ranges. `--all`
-(also available as `--non-interactive`) includes dirty merged worktrees and
-orphaned directories. Merged branches without worktrees are included when
+The interactive menu accepts comma-separated numbers and ranges. Dirty merged
+worktrees remain visible with a warning but are skipped if selected. `--all`
+(also available as `--non-interactive`) likewise skips registered worktrees
+with uncommitted changes while continuing with safe candidates and orphaned
+directories. Merged branches without worktrees are included when
 `prune_stale_branches` is enabled. Add `--json` (which requires `--all`) to
-emit the aggregate counts and a per-item list of each worktree, its branch, and
-whether removal succeeded.
+emit aggregate counts and a per-item list including skipped items and their
+reasons.
 
 ## Running Commands in Worktrees
 

--- a/docs/cli/cleanup.md
+++ b/docs/cli/cleanup.md
@@ -18,6 +18,9 @@ The command displays a numbered list. Select one or more entries with:
 
 Press Enter without a selection to cancel.
 
+Dirty merged worktrees remain visible with a warning. Selecting one records it
+as skipped rather than removing the worktree or its branch.
+
 ## Non-interactive cleanup
 
 ```bash
@@ -25,9 +28,11 @@ lazyworktree cleanup --all
 lazyworktree cleanup --non-interactive # Alias for --all
 ```
 
-`--all` removes every candidate without reading from standard input. This
-includes dirty merged worktrees and orphaned directories, so inspect with the
-interactive command first if the repository state is uncertain.
+`--all` attempts every candidate without reading from standard input. Registered
+worktrees with uncommitted changes are reported and skipped, while clean
+worktrees, stale branches, and orphaned directories remain eligible for
+cleanup. Worktree status is rechecked immediately before removal, so changes
+made after candidate discovery are protected as well.
 
 ## JSON output
 
@@ -42,13 +47,16 @@ output. Progress messages, including terminate command notices, are suppressed.
 The object reports aggregate counts alongside a per-item list. Each item records
 its `kind` (`worktree`, `branch`, or `orphan`), the worktree `path`, its
 `branch`, the detection `source` (`pr`, `git`, or `both`), whether the branch was
-deleted, and whether the removal failed.
+deleted, whether the item was skipped, and whether the removal failed. Skipped
+worktrees include a `skip_reason`; safety skips do not cause a non-zero exit,
+while actual removal failures do.
 
 ```json
 {
   "worktrees": 1,
   "branches": 1,
   "orphans": 0,
+  "skipped": 0,
   "failures": 0,
   "items": [
     {
@@ -57,6 +65,7 @@ deleted, and whether the removal failed.
       "branch": "feature",
       "source": "pr",
       "branch_deleted": true,
+      "skipped": false,
       "failed": false
     },
     {
@@ -64,6 +73,7 @@ deleted, and whether the removal failed.
       "branch": "stale",
       "source": "git",
       "branch_deleted": true,
+      "skipped": false,
       "failed": false
     }
   ]
@@ -79,6 +89,7 @@ Cleanup considers:
 - merged local branches without worktrees when `prune_stale_branches` is enabled
 - non-hidden directories in the repository's worktree directory that Git no longer registers
 
-Terminate commands run before a worktree is removed. Orphaned directories are
-revalidated against Git immediately before deletion. Any failed candidate
-removal causes a non-zero exit.
+Terminate commands run only after a worktree has passed the final clean-status
+check. Orphaned directories are revalidated against Git immediately before
+deletion. Any failed candidate removal causes a non-zero exit; skipped dirty
+worktrees are reported without being treated as failures.

--- a/internal/app/screen/help.go
+++ b/internal/app/screen/help.go
@@ -178,7 +178,7 @@ Supported: Letters (a-z, A-Z), numbers (0-9), and hyphens (-). See help for full
 - Command palette: Open commit screen (for staged changes, or prompt to stage all)
 - Commit screen: Ctrl+G opens it from anywhere, and c opens it from the status pane; subject stays on the first line, body below; Tab switches field, Enter moves from subject to body, Ctrl+S saves, Ctrl+O auto-generates, Ctrl+X opens the external editor when configured
 - Custom commands prefixed with _: appear in the command palette only
-- CLI automation: use lazyworktree cleanup, lazyworktree doctor --json, lazyworktree worktrees resolve, and lazyworktree describe from the shell
+- CLI automation: use lazyworktree cleanup (which skips registered worktrees with uncommitted changes), lazyworktree doctor --json, lazyworktree worktrees resolve, and lazyworktree describe from the shell
 - ?: Show this help
 
 **{{HELP_REPO_OPS}}Repository Operations**

--- a/internal/bootstrap/commands.go
+++ b/internal/bootstrap/commands.go
@@ -1309,6 +1309,8 @@ func emitCleanupJSON(summary cli.CleanupSummary) error {
 			Branch:        item.Branch,
 			Source:        item.Source,
 			BranchDeleted: item.BranchDeleted,
+			Skipped:       item.Skipped,
+			SkipReason:    item.SkipReason,
 			Failed:        item.Failed,
 			Error:         item.Error,
 		})
@@ -1317,6 +1319,7 @@ func emitCleanupJSON(summary cli.CleanupSummary) error {
 		Worktrees: summary.Worktrees,
 		Branches:  summary.Branches,
 		Orphans:   summary.Orphans,
+		Skipped:   summary.Skipped,
 		Failures:  summary.Failures,
 		Items:     items,
 	}

--- a/internal/bootstrap/commands_json.go
+++ b/internal/bootstrap/commands_json.go
@@ -55,6 +55,8 @@ type cleanupItemJSON struct {
 	Branch        string `json:"branch,omitempty"`
 	Source        string `json:"source,omitempty"`
 	BranchDeleted bool   `json:"branch_deleted"`
+	Skipped       bool   `json:"skipped"`
+	SkipReason    string `json:"skip_reason,omitempty"`
 	Failed        bool   `json:"failed"`
 	Error         string `json:"error,omitempty"`
 }
@@ -64,6 +66,7 @@ type cleanupJSON struct {
 	Worktrees int               `json:"worktrees"`
 	Branches  int               `json:"branches"`
 	Orphans   int               `json:"orphans"`
+	Skipped   int               `json:"skipped"`
 	Failures  int               `json:"failures"`
 	Items     []cleanupItemJSON `json:"items"`
 }

--- a/internal/bootstrap/subcommands_test.go
+++ b/internal/bootstrap/subcommands_test.go
@@ -969,10 +969,12 @@ func TestEmitCleanupJSON(t *testing.T) {
 		Worktrees: 1,
 		Branches:  1,
 		Orphans:   0,
+		Skipped:   1,
 		Failures:  1,
 		Items: []cli.CleanupItem{
 			{Kind: cli.CleanupKindWorktree, Path: "/wt/feature", Branch: "feature", Source: "pr", BranchDeleted: true},
 			{Kind: cli.CleanupKindBranch, Branch: "stale", Source: "git", BranchDeleted: true},
+			{Kind: cli.CleanupKindWorktree, Path: "/wt/dirty", Branch: "dirty", Source: "git", Skipped: true, SkipReason: "uncommitted changes"},
 			{Kind: cli.CleanupKindOrphan, Path: "/wt/orphan", Failed: true, Error: "could not be revalidated safely"},
 		},
 	}
@@ -985,15 +987,18 @@ func TestEmitCleanupJSON(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(out), &decoded))
 	assert.Equal(t, 1, decoded.Worktrees)
 	assert.Equal(t, 1, decoded.Branches)
+	assert.Equal(t, 1, decoded.Skipped)
 	assert.Equal(t, 1, decoded.Failures)
-	require.Len(t, decoded.Items, 3)
+	require.Len(t, decoded.Items, 4)
 	assert.Equal(t, "worktree", decoded.Items[0].Kind)
 	assert.Equal(t, "/wt/feature", decoded.Items[0].Path)
 	assert.Equal(t, "feature", decoded.Items[0].Branch)
 	assert.True(t, decoded.Items[0].BranchDeleted)
 	assert.Equal(t, "stale", decoded.Items[1].Branch)
-	assert.True(t, decoded.Items[2].Failed)
-	assert.Equal(t, "could not be revalidated safely", decoded.Items[2].Error)
+	assert.True(t, decoded.Items[2].Skipped)
+	assert.Equal(t, "uncommitted changes", decoded.Items[2].SkipReason)
+	assert.True(t, decoded.Items[3].Failed)
+	assert.Equal(t, "could not be revalidated safely", decoded.Items[3].Error)
 }
 
 func TestHandleRenameFlags(t *testing.T) {

--- a/internal/cli/cleanup.go
+++ b/internal/cli/cleanup.go
@@ -20,6 +20,7 @@ type cleanupGitService interface {
 	gitService
 	GetMainBranch(ctx context.Context) string
 	GetMergedBranches(ctx context.Context, baseBranch string) []string
+	RunGitWithCombinedOutput(ctx context.Context, args []string, cwd string, env map[string]string) ([]byte, error)
 }
 
 type cleanupCandidateKind int
@@ -42,6 +43,7 @@ type cleanupResult struct {
 	worktrees int
 	branches  int
 	orphans   int
+	skipped   int
 	failures  int
 	items     []CleanupItem
 }
@@ -60,6 +62,8 @@ type CleanupItem struct {
 	Branch        string
 	Source        string
 	BranchDeleted bool
+	Skipped       bool
+	SkipReason    string
 	Failed        bool
 	Error         string
 }
@@ -70,6 +74,7 @@ type CleanupSummary struct {
 	Worktrees int
 	Branches  int
 	Orphans   int
+	Skipped   int
 	Failures  int
 	Items     []CleanupItem
 }
@@ -120,6 +125,7 @@ func Cleanup(
 		Worktrees: result.worktrees,
 		Branches:  result.branches,
 		Orphans:   result.orphans,
+		Skipped:   result.skipped,
 		Failures:  result.failures,
 		Items:     result.items,
 	}
@@ -347,6 +353,19 @@ func executeCleanup(
 	for _, candidate := range candidates {
 		switch candidate.kind {
 		case cleanupWorktree:
+			hasChanges, err := cleanupWorktreeHasUncommittedChanges(ctx, gitSvc, candidate.worktree.Path)
+			if err != nil {
+				appendSkippedCleanupItem(&result, candidate, "could not verify worktree status")
+				if !silent {
+					fmt.Fprintf(stderr, "Warning: skipped worktree %s because its status could not be verified: %v\n", candidate.worktree.Path, err)
+				}
+				continue
+			}
+			if hasChanges {
+				appendSkippedCleanupItem(&result, candidate, "uncommitted changes")
+				continue
+			}
+
 			runCleanupTerminateCommands(ctx, gitSvc, cfg, candidate.worktree, silent, stderr)
 			removed := gitSvc.RunCommandChecked(
 				ctx,
@@ -423,6 +442,31 @@ func executeCleanup(
 	return result
 }
 
+func appendSkippedCleanupItem(result *cleanupResult, candidate cleanupCandidate, reason string) {
+	result.skipped++
+	result.items = append(result.items, CleanupItem{
+		Kind:       CleanupKindWorktree,
+		Path:       candidate.worktree.Path,
+		Branch:     candidate.branch,
+		Source:     candidate.source,
+		Skipped:    true,
+		SkipReason: reason,
+	})
+}
+
+func cleanupWorktreeHasUncommittedChanges(ctx context.Context, gitSvc cleanupGitService, path string) (bool, error) {
+	output, err := gitSvc.RunGitWithCombinedOutput(
+		ctx,
+		[]string{"git", "status", "--porcelain", "--untracked-files=all", "--ignore-submodules=none"},
+		path,
+		nil,
+	)
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(string(output)) != "", nil
+}
+
 // worktreeCleanupError describes which step of a worktree cleanup failed.
 func worktreeCleanupError(removed, branchDeleted bool) string {
 	switch {
@@ -496,8 +540,8 @@ func (c cleanupCandidate) description() string {
 	switch c.kind {
 	case cleanupWorktree:
 		status := sourceDescription(c.source)
-		if c.worktree.Dirty || c.worktree.Untracked > 0 || c.worktree.Modified > 0 || c.worktree.Staged > 0 {
-			status += "; HAS UNCOMMITTED CHANGES"
+		if cleanupWorktreeInfoHasUncommittedChanges(c.worktree) {
+			status += "; HAS UNCOMMITTED CHANGES (will be skipped)"
 		}
 		return fmt.Sprintf("worktree %s (branch %s; %s)", filepath.Base(c.worktree.Path), c.branch, status)
 	case cleanupBranch:
@@ -505,6 +549,10 @@ func (c cleanupCandidate) description() string {
 	default:
 		return fmt.Sprintf("orphaned directory %s", c.orphanPath)
 	}
+}
+
+func cleanupWorktreeInfoHasUncommittedChanges(wt *models.WorktreeInfo) bool {
+	return wt != nil && (wt.Dirty || wt.Untracked > 0 || wt.Modified > 0 || wt.Staged > 0)
 }
 
 func sourceDescription(source string) string {
@@ -521,16 +569,26 @@ func sourceDescription(source string) string {
 func formatCleanupResult(result cleanupResult) string {
 	parts := make([]string, 0, 4)
 	var wtLines []string
+	var skippedLines []string
 	if result.worktrees > 0 {
 		parts = append(parts, fmt.Sprintf("%d merged %s removed", result.worktrees, pluralise(result.worktrees, "worktree", "worktrees")))
 		for _, item := range result.items {
-			if item.Kind == CleanupKindWorktree && !item.Failed {
+			if item.Kind == CleanupKindWorktree && !item.Failed && !item.Skipped {
 				name := filepath.Base(item.Path)
 				if name != item.Branch {
 					wtLines = append(wtLines, fmt.Sprintf("  • %s (%s)", name, item.Branch))
 				} else {
 					wtLines = append(wtLines, fmt.Sprintf("  • %s", name))
 				}
+			}
+		}
+	}
+	if result.skipped > 0 {
+		parts = append(parts, fmt.Sprintf("%d merged %s skipped", result.skipped, pluralise(result.skipped, "worktree", "worktrees")))
+		for _, item := range result.items {
+			if item.Skipped {
+				name := filepath.Base(item.Path)
+				skippedLines = append(skippedLines, fmt.Sprintf("  • %s (%s)", name, item.SkipReason))
 			}
 		}
 	}
@@ -547,8 +605,9 @@ func formatCleanupResult(result cleanupResult) string {
 		return "Nothing was cleaned up."
 	}
 	msg := "Cleanup complete: " + strings.Join(parts, ", ") + "."
-	if len(wtLines) > 0 {
-		msg += "\n" + strings.Join(wtLines, "\n")
+	detailLines := slices.Concat(wtLines, skippedLines)
+	if len(detailLines) > 0 {
+		msg += "\n" + strings.Join(detailLines, "\n")
 	}
 	return msg
 }

--- a/internal/cli/cleanup_test.go
+++ b/internal/cli/cleanup_test.go
@@ -3,16 +3,68 @@ package cli
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/chmouel/lazyworktree/internal/config"
+	"github.com/chmouel/lazyworktree/internal/git"
 	"github.com/chmouel/lazyworktree/internal/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestCleanupWorktreeDetectsIgnoredSubmoduleChanges(t *testing.T) {
+	t.Parallel()
+
+	for _, source := range []string{".gitmodules", "local"} {
+		for _, ignore := range []string{"dirty", "all"} {
+			for _, change := range []string{"tracked", "untracked"} {
+				t.Run(source+"/"+ignore+"/"+change, func(t *testing.T) {
+					t.Parallel()
+					ctx := context.Background()
+					svc := git.NewService(nil, nil)
+					runGit := func(dir string, args ...string) string {
+						t.Helper()
+						args = append([]string{"git", "-c", "user.name=Test", "-c", "user.email=test@example.com", "-c", "commit.gpgsign=false"}, args...)
+						output, err := svc.RunGitWithCombinedOutput(ctx, args, dir, nil)
+						require.NoError(t, err, "%s", output)
+						return strings.TrimSpace(string(output))
+					}
+
+					subRepo := t.TempDir()
+					runGit(subRepo, "init")
+					require.NoError(t, os.WriteFile(filepath.Join(subRepo, "tracked.txt"), []byte("original\n"), 0o600))
+					runGit(subRepo, "add", ".")
+					runGit(subRepo, "commit", "-m", "Initial submodule")
+
+					repo := t.TempDir()
+					runGit(repo, "init")
+					runGit(repo, "-c", "protocol.file.allow=always", "submodule", "add", subRepo, "sub")
+					if source == ".gitmodules" {
+						runGit(repo, "config", "-f", ".gitmodules", "submodule.sub.ignore", ignore)
+					} else {
+						runGit(repo, "config", "--local", "submodule.sub.ignore", ignore)
+					}
+					runGit(repo, "add", ".")
+					runGit(repo, "commit", "-m", "Add submodule")
+
+					dirty, err := cleanupWorktreeHasUncommittedChanges(ctx, svc, repo)
+					require.NoError(t, err)
+					require.False(t, dirty, "clean submodule should allow cleanup")
+
+					require.NoError(t, os.WriteFile(filepath.Join(repo, "sub", change+".txt"), []byte("unsaved work\n"), 0o600))
+					require.Empty(t, runGit(repo, "status", "--porcelain", "--untracked-files=all"), "ordinary status should hide the submodule change")
+					dirty, err = cleanupWorktreeHasUncommittedChanges(ctx, svc, repo)
+					require.NoError(t, err)
+					assert.True(t, dirty, "cleanup must detect hidden submodule changes")
+				})
+			}
+		}
+	}
+}
 
 func TestParseCleanupSelection(t *testing.T) {
 	t.Parallel()
@@ -66,6 +118,9 @@ func TestCleanupInteractiveSelection(t *testing.T) {
 		mainBranch:          "main",
 		mergedBranches:      []string{"feature", "stale"},
 		runCommandCheckedOK: true,
+		runGitCombinedOutputs: map[string][]byte{
+			featurePath: []byte("1 .M file.txt\n"),
+		},
 		worktrees: []*models.WorktreeInfo{
 			{Path: "/main", Branch: "main", IsMain: true},
 			{Path: featurePath, Branch: "feature", Dirty: true},
@@ -77,18 +132,27 @@ func TestCleanupInteractiveSelection(t *testing.T) {
 	cfg.PruneStaleBranches = true
 
 	var stderr bytes.Buffer
-	_, err := Cleanup(context.Background(), svc, cfg, false, false, strings.NewReader("1,3\n"), &stderr)
+	summary, err := Cleanup(context.Background(), svc, cfg, false, false, strings.NewReader("1,3\n"), &stderr)
 	require.NoError(t, err)
 
 	assert.Contains(t, stderr.String(), "[1] worktree feature")
-	assert.Contains(t, stderr.String(), "HAS UNCOMMITTED CHANGES")
+	assert.Contains(t, stderr.String(), "HAS UNCOMMITTED CHANGES (will be skipped)")
 	assert.Contains(t, stderr.String(), "[2] branch stale")
 	assert.Contains(t, stderr.String(), "[3] orphaned directory")
-	assert.Contains(t, stderr.String(), "1 merged worktree removed")
+	assert.Contains(t, stderr.String(), "1 merged worktree skipped")
+	assert.Contains(t, stderr.String(), "uncommitted changes")
 	assert.Contains(t, stderr.String(), "1 orphaned directory removed")
 	assert.NoDirExists(t, orphanPath)
-	assert.True(t, commandWasRun(svc.runCommandCheckedCalls, "git", "worktree", "remove", "--force", featurePath))
+	assert.False(t, commandWasRun(svc.runCommandCheckedCalls, "git", "worktree", "remove", "--force", featurePath))
+	assert.False(t, commandWasRun(svc.runCommandCheckedCalls, "git", "branch", "-D", "feature"))
 	assert.False(t, commandWasRun(svc.runCommandCheckedCalls, "git", "branch", "-D", "stale"))
+	assert.Equal(t, 1, summary.Skipped)
+	assert.Equal(t, 1, summary.Orphans)
+	require.Len(t, summary.Items, 2)
+	skippedItem := findCleanupItem(summary.Items, CleanupKindWorktree)
+	require.NotNil(t, skippedItem)
+	assert.True(t, skippedItem.Skipped)
+	assert.Equal(t, "uncommitted changes", skippedItem.SkipReason)
 }
 
 func TestCleanupAllIncludesEveryCandidate(t *testing.T) {
@@ -142,6 +206,133 @@ func TestCleanupAllIncludesEveryCandidate(t *testing.T) {
 	branchItem := findCleanupItem(summary.Items, CleanupKindBranch)
 	require.NotNil(t, branchItem)
 	assert.Equal(t, "stale", branchItem.Branch)
+}
+
+func TestCleanupAllSkipsDirtyWorktreeAndContinues(t *testing.T) {
+	t.Parallel()
+
+	worktreeDir := t.TempDir()
+	repoDir := filepath.Join(worktreeDir, "repo")
+	cleanPath := filepath.Join(repoDir, "clean")
+	featurePath := filepath.Join(repoDir, "feature")
+	orphanPath := filepath.Join(repoDir, "orphan")
+	require.NoError(t, os.MkdirAll(cleanPath, 0o750))
+	require.NoError(t, os.MkdirAll(featurePath, 0o750))
+	require.NoError(t, os.MkdirAll(orphanPath, 0o750))
+
+	svc := &fakeGitService{
+		resolveRepoName:     "repo",
+		mainWorktreePath:    "/main",
+		mainBranch:          "main",
+		mergedBranches:      []string{"clean", "feature", "stale"},
+		runCommandCheckedOK: true,
+		runGitCombinedOutputs: map[string][]byte{
+			featurePath: []byte("?? untracked.txt\n"),
+		},
+		worktrees: []*models.WorktreeInfo{
+			{Path: "/main", Branch: "main", IsMain: true},
+			{Path: cleanPath, Branch: "clean"},
+			{Path: featurePath, Branch: "feature"},
+		},
+	}
+	cfg := config.DefaultConfig()
+	cfg.WorktreeDir = worktreeDir
+	cfg.DisablePR = true
+	cfg.PruneStaleBranches = true
+
+	var stderr bytes.Buffer
+	summary, err := Cleanup(context.Background(), svc, cfg, true, false, strings.NewReader(""), &stderr)
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr.String(), "1 merged worktree removed")
+	assert.Contains(t, stderr.String(), "1 merged worktree skipped")
+	assert.Contains(t, stderr.String(), "1 stale branch deleted")
+	assert.Contains(t, stderr.String(), "1 orphaned directory removed")
+	assert.Contains(t, stderr.String(), "  • clean\n")
+	assert.Contains(t, stderr.String(), "  • feature (uncommitted changes)")
+	assert.True(t, commandWasRun(svc.runCommandCheckedCalls, "git", "worktree", "remove", "--force", cleanPath))
+	assert.False(t, commandWasRun(svc.runCommandCheckedCalls, "git", "worktree", "remove", "--force", featurePath))
+	assert.False(t, commandWasRun(svc.runCommandCheckedCalls, "git", "branch", "-D", "feature"))
+	assert.True(t, commandWasRun(svc.runCommandCheckedCalls, "git", "branch", "-D", "stale"))
+	assert.NoDirExists(t, orphanPath)
+	assert.Equal(t, 1, summary.Worktrees)
+	assert.Equal(t, 1, summary.Branches)
+	assert.Equal(t, 1, summary.Orphans)
+	assert.Equal(t, 1, summary.Skipped)
+	assert.Equal(t, 0, summary.Failures)
+}
+
+func TestCleanupRechecksWorktreeStatusBeforeRemoval(t *testing.T) {
+	t.Parallel()
+
+	worktreeDir := t.TempDir()
+	repoDir := filepath.Join(worktreeDir, "repo")
+	featurePath := filepath.Join(repoDir, "feature")
+	require.NoError(t, os.MkdirAll(featurePath, 0o750))
+
+	svc := &fakeGitService{
+		resolveRepoName:     "repo",
+		mainWorktreePath:    "/main",
+		mainBranch:          "main",
+		mergedBranches:      []string{"feature"},
+		runCommandCheckedOK: true,
+		runGitCombinedOutputs: map[string][]byte{
+			featurePath: []byte("1 .M changed-after-discovery.txt\n"),
+		},
+		worktrees: []*models.WorktreeInfo{
+			{Path: "/main", Branch: "main", IsMain: true},
+			{Path: featurePath, Branch: "feature"},
+		},
+	}
+	cfg := config.DefaultConfig()
+	cfg.WorktreeDir = worktreeDir
+	cfg.DisablePR = true
+
+	var stderr bytes.Buffer
+	summary, err := Cleanup(context.Background(), svc, cfg, true, false, strings.NewReader(""), &stderr)
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr.String(), "1 merged worktree skipped")
+	assert.False(t, commandWasRun(svc.runCommandCheckedCalls, "git", "worktree", "remove", "--force", featurePath))
+	assert.Equal(t, 1, summary.Skipped)
+	assert.Equal(t, 0, summary.Failures)
+}
+
+func TestCleanupSkipsWorktreeWhenStatusCannotBeVerified(t *testing.T) {
+	t.Parallel()
+
+	worktreeDir := t.TempDir()
+	repoDir := filepath.Join(worktreeDir, "repo")
+	featurePath := filepath.Join(repoDir, "feature")
+	require.NoError(t, os.MkdirAll(featurePath, 0o750))
+
+	statusErr := errors.New("status unavailable")
+	svc := &fakeGitService{
+		resolveRepoName:     "repo",
+		mainWorktreePath:    "/main",
+		mainBranch:          "main",
+		mergedBranches:      []string{"feature"},
+		runCommandCheckedOK: true,
+		runGitCombinedErrors: map[string]error{
+			featurePath: statusErr,
+		},
+		worktrees: []*models.WorktreeInfo{
+			{Path: "/main", Branch: "main", IsMain: true},
+			{Path: featurePath, Branch: "feature"},
+		},
+	}
+	cfg := config.DefaultConfig()
+	cfg.WorktreeDir = worktreeDir
+	cfg.DisablePR = true
+
+	var stderr bytes.Buffer
+	summary, err := Cleanup(context.Background(), svc, cfg, true, false, strings.NewReader(""), &stderr)
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr.String(), "status could not be verified")
+	assert.False(t, commandWasRun(svc.runCommandCheckedCalls, "git", "worktree", "remove", "--force", featurePath))
+	assert.Equal(t, 1, summary.Skipped)
+	assert.Equal(t, "could not verify worktree status", summary.Items[0].SkipReason)
 }
 
 func TestCleanupCancelled(t *testing.T) {

--- a/internal/cli/operations_test.go
+++ b/internal/cli/operations_test.go
@@ -69,6 +69,8 @@ type fakeGitService struct {
 	runCommandCheckedCalls [][]string
 	runCommandQuietOK      bool
 	runCommandQuietCalls   [][]string
+	runGitCombinedOutputs  map[string][]byte
+	runGitCombinedErrors   map[string]error
 }
 
 func (f *fakeGitService) CheckoutPRBranch(_ context.Context, _ int, _, localBranch string) bool {
@@ -196,6 +198,18 @@ func (f *fakeGitService) RunGit(_ context.Context, args []string, _ string, _ []
 		return ""
 	}
 	return f.runGitOutput[filepath.Join(args...)]
+}
+
+func (f *fakeGitService) RunGitWithCombinedOutput(_ context.Context, _ []string, cwd string, _ map[string]string) ([]byte, error) {
+	if f.runGitCombinedErrors != nil {
+		if err, ok := f.runGitCombinedErrors[cwd]; ok {
+			return nil, err
+		}
+	}
+	if f.runGitCombinedOutputs != nil {
+		return f.runGitCombinedOutputs[cwd], nil
+	}
+	return nil, nil
 }
 
 func contains(s, substr string) bool {

--- a/lazyworktree.1
+++ b/lazyworktree.1
@@ -278,19 +278,20 @@ Remove merged worktrees, stale branches, and orphaned worktree directories witho
 .PP
 By default, displays a numbered menu. Select entries with individual numbers, comma-separated numbers, ranges, or \fBall\fR. Press Enter without a selection to cancel.
 Merged local branches without worktrees are included when \fBprune_stale_branches\fR is enabled.
+Dirty merged worktrees remain visible with a warning and are skipped if selected.
 .
 .PP
-Terminate commands run before merged worktrees are removed. Orphaned directories are revalidated against Git immediately before deletion.
+Terminate commands run only before eligible clean merged worktrees are removed. Orphaned directories are revalidated against Git immediately before deletion.
 .
 .PP
 .B Options:
 .TP
 .B \-\-all\fR, \fB\-\-non\-interactive
-Remove every candidate without prompting. This includes dirty merged worktrees and orphaned directories. Any failed candidate removal causes a non-zero exit.
+Attempt every candidate without prompting. Registered worktrees with uncommitted changes are reported and skipped; clean worktrees, stale branches, and orphaned directories remain eligible for cleanup. Worktree status is rechecked immediately before removal. Actual candidate failures cause a non-zero exit, while safety skips do not.
 .
 .TP
 .B \-\-json
-Emit a JSON object to standard output describing the cleanup result, including aggregate counts and a per-item list recording each worktree, its branch, the detection source, and whether removal succeeded. Requires \fB\-\-all\fR. Progress messages, including terminate command notices, are suppressed.
+Emit a JSON object to standard output describing the cleanup result, including aggregate counts and a per-item list recording each worktree, its branch, the detection source, whether it was skipped, and whether removal succeeded. Skipped worktrees include a reason. Requires \fB\-\-all\fR. Progress messages, including terminate command notices, are suppressed.
 .
 .SS exec
 Run a command or trigger a custom command key action in a worktree from the CLI.


### PR DESCRIPTION
Cleanup now checks merged worktrees for uncommitted changes before removal and checks again immediately before deleting them. Dirty worktrees stay visible, are reported as skipped in interactive, --all, and JSON output, and do not block cleanup of other candidates.

This prevents cleanup from deleting local work while preserving existing cleanup for clean worktrees, stale branches, and orphaned directories.

Tests: `go test ./internal/cli ./internal/bootstrap ./internal/app/screen`